### PR TITLE
added firefox binary path to config

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -7,4 +7,7 @@
 
 google_api_key=''
 google_cx_id=''
-firefox_exe_path = r'C:\Program Files\Mozilla Firefox\firefox.exe'
+
+firefox_exe_path = r'/usr/bin/firefox' #change the path according to your system.
+#the value can be empty if you don't need it.
+#firefox_exe_path = ''

--- a/config.example.py
+++ b/config.example.py
@@ -7,3 +7,4 @@
 
 google_api_key=''
 google_cx_id=''
+firefox_exe_path = r'C:\Program Files\Mozilla Firefox\firefox.exe'

--- a/config.example.py
+++ b/config.example.py
@@ -8,6 +8,4 @@
 google_api_key=''
 google_cx_id=''
 
-firefox_exe_path = r'/usr/bin/firefox' #change the path according to your system.
-#the value can be empty if you don't need it.
-#firefox_exe_path = ''
+firefox_path = '' # change the path according to your needs (e.g: /usr/bin/firefox).

--- a/docs/googlesearch.md
+++ b/docs/googlesearch.md
@@ -27,6 +27,8 @@ If you have a Google search console API key, all you have to do is to edit the f
 ### Using the webdriver
 
 By default, PhoneInfo uses Selenium to handle Google search feature. When running OSINT scans, you will usually be blacklisted very easily by Google, which will ask the tool to complete a captcha. Nothing more simple, just complete the captcha that appears on the firefox window. Then press ENTER in the CLI to tell the tool it can continue the scanning process.
+You can mention the Firefox executable path in `config.py` or leave it blank to use default configuration.
+Mentioning the path is recommended for Windows users
 
 Still having issues with Google captcha ? Please [open an issue](https://github.com/sundowndev/PhoneInfoga/issues).
 **Be careful, the cookie contain your IP address.**

--- a/docs/googlesearch.md
+++ b/docs/googlesearch.md
@@ -27,8 +27,8 @@ If you have a Google search console API key, all you have to do is to edit the f
 ### Using the webdriver
 
 By default, PhoneInfo uses Selenium to handle Google search feature. When running OSINT scans, you will usually be blacklisted very easily by Google, which will ask the tool to complete a captcha. Nothing more simple, just complete the captcha that appears on the firefox window. Then press ENTER in the CLI to tell the tool it can continue the scanning process.
-You can mention the Firefox executable path in `config.py` or leave it blank to use default configuration.
-Mentioning the path is recommended for Windows users
+
+If the tool can't find your browser executable, you can specify the Firefox executable path in `config.py` or leave it blank to use the default configuration.
 
 Still having issues with Google captcha ? Please [open an issue](https://github.com/sundowndev/PhoneInfoga/issues).
 **Be careful, the cookie contain your IP address.**

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -24,49 +24,9 @@ browser = None
 def closeBrowser():
     if browser is not None:
         browser.quit()
-<<<<<<< HEAD
-        
-def get_proxies(fo=fo):
-    driver = webdriver.Firefox(firefox_options=fo)
-    driver.get("https://free-proxy-list.net/")
-    proxies = driver.find_elements_by_css_selector("tr[role='row']")
-    for p in proxies:
-        result = p.text.split(" ")
-        if result[7] == "yes":
-            PROXIES.append(result[0]+":"+result[1])
-    driver.close()
-    return PROXIES
-
-def proxy_driver(PROXIES,fo=fo, binary = None):
-    prox = Proxy()
-    if PROXIES:
-        pxy = PROXIES[-1]
-    else:
-        info("Proxies used up (%s)" % len(PROXIES))
-        PROXIES = get_proxies()
-        print(PROXIES)
-        pxy = PROXIES[-1]
-    info('Trying proxy '+pxy)
-    proxy = Proxy({
-        'proxyType': ProxyType.MANUAL,
-        'httpProxy': pxy,
-        'ftpProxy': pxy,
-        'sslProxy': pxy,
-        'noProxy': '' 
-    })
-    driver = None
-    if binary==None:
-        driver  = webdriver.Firefox(firefox_options=fo,proxy=proxy)
-    else:
-        driver = webdriver.Firefox(firefox_options=fo, proxy=proxy,firefox_binary=binary)
-    return driver
-
-def search(req, stop,count=0):
-=======
 
 def search(req, stop):
-    time.sleep(10)
->>>>>>> parent of cd8e2b8... rotating proxy
+    #time.sleep(10)
     global browser
 
     if google_api_key and google_cx_id:
@@ -91,14 +51,8 @@ def search(req, stop):
 
         soup = BeautifulSoup(htmlBody, 'html5lib')
 
-<<<<<<< HEAD
-        if soup.find("div", id="recaptcha") is not None:
-            warn('Temporary blacklisted from Google search.')
-            return search(req,stop,count=1)
-=======
         while soup.find("div", id="recaptcha") is not None:
             warn('You are temporary blacklisted from Google search. Complete the captcha then press ENTER.')
->>>>>>> parent of cd8e2b8... rotating proxy
             token = ask('>')
             htmlBody = browser.find_element_by_css_selector("body").get_attribute('innerHTML')
             soup = BeautifulSoup(htmlBody, 'html5lib')

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 from bs4 import BeautifulSoup
 from lib.output import *
 from lib.request import send
+import os
 from config import *
 
 from selenium import webdriver
@@ -25,7 +26,7 @@ def closeBrowser():
         browser.quit()
 
 def search(req, stop):
-    time.sleep(5)
+    time.sleep(8)
     global browser
 
     if google_api_key and google_cx_id:
@@ -35,8 +36,11 @@ def search(req, stop):
         if os.environ.get('webdriverRemote'):
             browser = webdriver.Remote(os.environ.get('webdriverRemote'), webdriver.DesiredCapabilities.FIREFOX.copy())
         else:
-            binary = FirefoxBinary(firefox_exe_path)
-            browser = webdriver.Firefox(firefox_binary=binary)
+            if os.name == 'nt':
+                binary = FirefoxBinary(firefox_exe_path)
+                browser = webdriver.Firefox(firefox_binary=binary)
+            else:
+                browser = webdriver.Firefox()
 
     try:
         REQ = urlencode({ 'q': req, 'num': stop, 'hl': 'en' })

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -15,6 +15,7 @@ from lib.request import send
 from config import *
 
 from selenium import webdriver
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 browser = None
 
@@ -32,7 +33,8 @@ def search(req, stop):
         if os.environ.get('webdriverRemote'):
             browser = webdriver.Remote(os.environ.get('webdriverRemote'), webdriver.DesiredCapabilities.FIREFOX.copy())
         else:
-            browser = webdriver.Firefox()
+            binary = FirefoxBinary(firefox_exe_path)
+            browser = webdriver.Firefox(firefox_binary=binary)
 
     try:
         REQ = urlencode({ 'q': req, 'num': stop, 'hl': 'en' })

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -60,20 +60,11 @@ def proxy_driver(PROXIES,fo=fo, binary = None):
         'sslProxy': pxy,
         'noProxy': '' 
     })
-    #prox.proxy_type = ProxyType.MANUAL
-    #prox.http_proxy = pxy
-    #prox.socks_proxy = pxy
-    #prox.ssl_proxy = pxy
-    #capabilities = webdriver.DesiredCapabilities.FIREFOX
-    #prox.add_to_capabilities(capabilities)
     driver = None
     if binary==None:
-        #driver = webdriver.Firefox(firefox_options=fo, desired_capabilities=capabilities)
         driver  = webdriver.Firefox(firefox_options=fo,proxy=proxy)
     else:
-        #driver = webdriver.Firefox(firefox_options=fo, desired_capabilities=capabilities,firefox_binary=binary)
         driver = webdriver.Firefox(firefox_options=fo, proxy=proxy,firefox_binary=binary)
-    #print('[-] Using proxy',pxy)
     return driver
 
 def search(req, stop,count=0):
@@ -112,8 +103,8 @@ def search(req, stop,count=0):
         soup = BeautifulSoup(htmlBody, 'html5lib')
 
         if soup.find("div", id="recaptcha") is not None:
+            warn('Temporary blacklisted from Google search.')
             return search(req,stop,count=1)
-            warn('You are temporary blacklisted from Google search. Complete the captcha then press ENTER.')
             token = ask('>')
             htmlBody = browser.find_element_by_css_selector("body").get_attribute('innerHTML')
             soup = BeautifulSoup(htmlBody, 'html5lib')

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -8,18 +8,31 @@
 import os
 import re
 import json
-import time
 from urllib.parse import urlencode
 from bs4 import BeautifulSoup
 from lib.output import *
 from lib.request import send
-import os
 from config import *
 
 from selenium import webdriver
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
-browser = None
+
+def getFirefoxBrowser():
+    if os.environ.get("webdriverRemote"):
+        return webdriver.Remote(
+            os.environ.get("webdriverRemote"),
+            webdriver.DesiredCapabilities.FIREFOX.copy(),
+        )
+
+    if firefox_path == "":
+        return webdriver.Firefox()
+
+    binary = FirefoxBinary(firefox_path)
+    return webdriver.Firefox(firefox_binary=binary)
+
+
+browser = getFirefoxBrowser()
 
 
 def closeBrowser():
@@ -28,25 +41,10 @@ def closeBrowser():
 
 
 def search(req, stop):
-    #time.sleep(10)
     global browser
 
     if google_api_key and google_cx_id:
         return searchApi(req, stop)
-
-    if browser is None:
-        if os.environ.get("webdriverRemote"):
-            browser = webdriver.Remote(
-                os.environ.get("webdriverRemote"),
-                webdriver.DesiredCapabilities.FIREFOX.copy(),
-            )
-        else:
-            if firefox_exe_path.lstrip() == '':
-                browser = webdriver.Firefox()
-            else:
-                #info(firefox_exe_path)
-                binary = FirefoxBinary(firefox_exe_path)
-                browser = webdriver.Firefox(firefox_binary=binary)
 
     try:
         REQ = urlencode({"q": req, "num": stop, "hl": "en"})

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -39,6 +39,7 @@ def search(req, stop):
             if firefox_exe_path.lstrip() == '':
                 browser = webdriver.Firefox()
             else:
+                #info(firefox_exe_path)
                 binary = FirefoxBinary(firefox_exe_path)
                 browser = webdriver.Firefox(firefox_binary=binary)
 

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -26,7 +26,7 @@ def closeBrowser():
         browser.quit()
 
 def search(req, stop):
-    time.sleep(8)
+    time.sleep(10)
     global browser
 
     if google_api_key and google_cx_id:
@@ -36,11 +36,11 @@ def search(req, stop):
         if os.environ.get('webdriverRemote'):
             browser = webdriver.Remote(os.environ.get('webdriverRemote'), webdriver.DesiredCapabilities.FIREFOX.copy())
         else:
-            if os.name == 'nt':
+            if firefox_exe_path.lstrip() == '':
+                browser = webdriver.Firefox()
+            else:
                 binary = FirefoxBinary(firefox_exe_path)
                 browser = webdriver.Firefox(firefox_binary=binary)
-            else:
-                browser = webdriver.Firefox()
 
     try:
         REQ = urlencode({ 'q': req, 'num': stop, 'hl': 'en' })

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -17,20 +17,14 @@ import os
 from config import *
 
 from selenium import webdriver
-from selenium.webdriver.firefox.options import DesiredCapabilities
-from selenium.webdriver.common.proxy import Proxy,ProxyType
 from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 browser = None
-count = 0
-fo = webdriver.FirefoxOptions()
-fo.add_argument("log-level=3")
-PROXIES = []
-fo.add_argument("--headless")
 
 def closeBrowser():
     if browser is not None:
         browser.quit()
+<<<<<<< HEAD
         
 def get_proxies(fo=fo):
     driver = webdriver.Firefox(firefox_options=fo)
@@ -68,16 +62,13 @@ def proxy_driver(PROXIES,fo=fo, binary = None):
     return driver
 
 def search(req, stop,count=0):
+=======
+
+def search(req, stop):
+    time.sleep(10)
+>>>>>>> parent of cd8e2b8... rotating proxy
     global browser
-    global PROXIES
-    if count == 1:
-        if browser:
-            browser.close()
-        browser = None
-        if len(PROXIES) > 0:
-            PROXIES.pop()
-    if len(PROXIES) == 0:
-        PROXIES = get_proxies()
+
     if google_api_key and google_cx_id:
         return searchApi(req, stop)
 
@@ -86,12 +77,10 @@ def search(req, stop,count=0):
             browser = webdriver.Remote(os.environ.get('webdriverRemote'), webdriver.DesiredCapabilities.FIREFOX.copy())
         else:
             if firefox_exe_path.lstrip() == '':
-                browser = proxy_driver(PROXIES)
-                #browser = webdriver.Firefox()
+                browser = webdriver.Firefox()
             else:
                 binary = FirefoxBinary(firefox_exe_path)
-                browser = proxy_driver(PROXIES,binary=binary)
-                #browser = webdriver.Firefox(firefox_binary=binary)
+                browser = webdriver.Firefox(firefox_binary=binary)
 
     try:
         REQ = urlencode({ 'q': req, 'num': stop, 'hl': 'en' })
@@ -102,9 +91,14 @@ def search(req, stop,count=0):
 
         soup = BeautifulSoup(htmlBody, 'html5lib')
 
+<<<<<<< HEAD
         if soup.find("div", id="recaptcha") is not None:
             warn('Temporary blacklisted from Google search.')
             return search(req,stop,count=1)
+=======
+        while soup.find("div", id="recaptcha") is not None:
+            warn('You are temporary blacklisted from Google search. Complete the captcha then press ENTER.')
+>>>>>>> parent of cd8e2b8... rotating proxy
             token = ask('>')
             htmlBody = browser.find_element_by_css_selector("body").get_attribute('innerHTML')
             soup = BeautifulSoup(htmlBody, 'html5lib')

--- a/lib/googlesearch.py
+++ b/lib/googlesearch.py
@@ -8,6 +8,7 @@
 import os
 import re
 import json
+import time
 from urllib.parse import urlencode
 from bs4 import BeautifulSoup
 from lib.output import *
@@ -24,6 +25,7 @@ def closeBrowser():
         browser.quit()
 
 def search(req, stop):
+    time.sleep(5)
     global browser
 
     if google_api_key and google_cx_id:


### PR DESCRIPTION
This should save users like me from WebDiver permission denied errors.

I've added Firefox Binary path to `config.example.py` file now. So when the users create the config file, they can specify the path and not have to encounter WebDriver errors the way I did.