### PR TITLE
Scanners - return error instead of exiting

### DIFF
--- a/pkg/scanners/local_test.go
+++ b/pkg/scanners/local_test.go
@@ -11,7 +11,7 @@ func TestLocalScan(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("should scan number", func(t *testing.T) {
-		result := localScanCLI(utils.LoggerService, "+1 718-521-2994")
+		result, err := localScanCLI(utils.LoggerService, "+1 718-521-2994")
 
 		expectedResult := &Number{
 			RawLocal:      "7185212994",
@@ -23,7 +23,8 @@ func TestLocalScan(t *testing.T) {
 			Carrier:       "",
 		}
 
-		assert.Equal(result, expectedResult, "they should be equal")
+		assert.Equal(expectedResult, result, "they should be equal")
+		assert.Nil(err, "they should be equal")
 	})
 
 	t.Run("should fail and return error", func(t *testing.T) {

--- a/pkg/scanners/numverify_test.go
+++ b/pkg/scanners/numverify_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	gock "gopkg.in/h2non/gock.v1"
+	"gopkg.in/sundowndev/phoneinfoga.v2/pkg/utils"
 )
 
 func TestNumverifyScanner(t *testing.T) {
@@ -39,9 +40,9 @@ func TestNumverifyScanner(t *testing.T) {
 			Reply(200).
 			JSON(expectedResult)
 
-		result, err := NumverifyScan(number)
+		result, err := numverifyScanCLI(utils.LoggerService, number)
 
-		assert.Equal(err, nil, "they should be equal")
+		assert.Nil(err, "they should be equal")
 		assert.Equal(result, &expectedResult, "they should be equal")
 
 		assert.Equal(gock.IsDone(), true, "there should have no pending mocks")
@@ -76,10 +77,33 @@ func TestNumverifyScanner(t *testing.T) {
 			Reply(200).
 			JSON(expectedResult)
 
-		result, err := NumverifyScan(number)
+		result, err := numverifyScanCLI(utils.LoggerService, number)
 
-		assert.Equal(err, nil, "they should be equal")
+		assert.Nil(err, "they should be equal")
 		assert.Equal(result, &expectedResult, "they should be equal")
+
+		assert.Equal(gock.IsDone(), true, "there should have no pending mocks")
+	})
+
+	t.Run("should return empty response and handle error properly", func(t *testing.T) {
+		defer gock.Off() // Flush pending mocks after test execution
+
+		number, _ := LocalScan("+123456789")
+
+		gock.New("http://numverify.com").
+			Get("/").
+			Reply(200).BodyString(`<html><body><input type="hidden" name="scl_request_secret" value="secret"/></body></html>`)
+
+		gock.New("https://numverify.com").
+			Get("/php_helper_scripts/phone_api.php").
+			MatchParam("secret_key", "7ccde16e862dfe7681297713e9e9cadb").
+			MatchParam("number", number.International).
+			Reply(200)
+
+		result, err := numverifyScanCLI(utils.LoggerService, number)
+
+		assert.EqualError(err, "EOF", "they should be equal")
+		assert.Nil(result, "they should be equal")
 
 		assert.Equal(gock.IsDone(), true, "there should have no pending mocks")
 	})

--- a/pkg/scanners/ovh_test.go
+++ b/pkg/scanners/ovh_test.go
@@ -34,7 +34,7 @@ func TestOVHScanner(t *testing.T) {
 
 		number, _ := LocalScan("+33 0365179268")
 
-		result := ovhScanCLI(utils.LoggerService, number)
+		result, err := ovhScanCLI(utils.LoggerService, number)
 
 		assert.Equal(result, &OVHScannerResponse{
 			Found:       true,
@@ -44,6 +44,7 @@ func TestOVHScanner(t *testing.T) {
 		}, "they should be equal")
 
 		assert.Equal(gock.IsDone(), true, "there should have no pending mocks")
+		assert.Nil(err, "they should be equal")
 	})
 
 	t.Run("should not find number on OVH", func(t *testing.T) {


### PR DESCRIPTION
Reference: #338; A bug from Numverify returning empty response make the program crash.