### PR TITLE
Enable support for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,12 +10,12 @@ builds:
   goos:
     - linux
     - darwin
+    - windows
   goarch:
     - 386
     - amd64
     - arm
     - arm64
-    - aarch64
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   replacements:

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 To install PhoneInfoga, you'll need to download the binary or build the software from its source code.
 
 !!! info
-    For now, only Linux and MacOS are supported. If you don't see your OS/arch on the [release page on GitHub](https://github.com/sundowndev/PhoneInfoga/releases), it means it's not explicitly supported. You can always build from source by yourself. Want your OS to be supported ? Please [open an issue on GitHub](https://github.com/sundowndev/PhoneInfoga/issues).
+    For now, only Linux, MacOS and Windows are supported. If you don't see your OS/arch on the [release page on GitHub](https://github.com/sundowndev/PhoneInfoga/releases), it means it's not explicitly supported. You can build from source by yourself anyway. Want your OS to be supported ? Please [open an issue on GitHub](https://github.com/sundowndev/PhoneInfoga/issues).
 
 ## Binary installation (recommanded)
 


### PR DESCRIPTION
Enable support for Windows so the next release can be used by Windows users.

Also remove aarch64 from goarch list. It was useless since it's an alias of 64bits arm.