### PR TITLE
Update install

### DIFF
--- a/support/scripts/install
+++ b/support/scripts/install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Bash installation script for UNIX systems only
-# Use it : curl -sSL https://raw.githubusercontent.com/sundowndev/PhoneInfoga/master/scripts/install | bash
+# Use it : curl -sSL https://raw.githubusercontent.com/sundowndev/PhoneInfoga/master/support/scripts/install | bash
 
 os="$(uname -s)_$(uname -m)"
 


### PR DESCRIPTION
As the scripts path have been changed to support, this 
`curl -sSL https://raw.githubusercontent.com/sundowndev/PhoneInfoga/master/scripts/install | bash`  is not working for installation. So I corrected that with `curl -sSL https://raw.githubusercontent.com/sundowndev/PhoneInfoga/master/support/scripts/install | bash`.  And its working.