### PR TITLE
Implement cache for async operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage
 coverage.*
 .idea
 api/assets.go
+*.db

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,112 @@
+package cache
+
+import (
+	"encoding/json"
+	"fmt"
+	bolt "go.etcd.io/bbolt"
+	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
+	"time"
+)
+
+const (
+	defaultFilename = "cache.db"
+	scanTasksBucket = "scans"
+	resultsBucket   = "numbers"
+)
+
+// DefaultKeyExpiration is the default value for temporary data (7 days)
+const DefaultKeyExpiration = 7 * (24 * time.Hour)
+
+type Cache struct {
+	Directory string
+	Filename  string
+	db        *bolt.DB
+}
+
+func (c *Cache) Init() error {
+	var filename string
+
+	if c.db != nil {
+		return fmt.Errorf("database was already initialized")
+	}
+
+	if c.Filename == "" {
+		filename = defaultFilename
+	}
+
+	db, err := bolt.Open(fmt.Sprintf("%s/%s", c.Directory, filename), 0666, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	c.db = db
+
+	err = c.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(scanTasksBucket))
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateBucketIfNotExists([]byte(resultsBucket))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Cache) CacheResults(n *scanners.ScanResult) error {
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(resultsBucket))
+
+		data, err := json.Marshal(n)
+		if err != nil {
+			return err
+		}
+
+		err = b.Put([]byte(n.Local.International), data)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Cache) GetResults(n *scanners.Number) (*scanners.ScanResult, error) {
+	results := &scanners.ScanResult{}
+
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(resultsBucket))
+
+		data := b.Get([]byte(n.International))
+
+		err := json.Unmarshal(data, results)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return results, err
+	}
+
+	return results, nil
+}
+
+func (c *Cache) Close() error {
+	return c.db.Close()
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
+	"testing"
+
+	assertion "github.com/stretchr/testify/assert"
+)
+
+func TestCache(t *testing.T) {
+	assert := assertion.New(t)
+
+	t.Run("database was already initialized", func(t *testing.T) {
+		c := &Cache{Directory: "."}
+		err := c.Init()
+		defer c.Close()
+
+		assert.NoError(err)
+
+		err = c.Init()
+
+		assert.EqualError(err, "database was already initialized")
+	})
+
+	t.Run("check if number is cached", func(t *testing.T) {
+
+	})
+
+	t.Run("add number to cache", func(t *testing.T) {
+		c := &Cache{Directory: "."}
+		err := c.Init()
+		defer c.Close()
+
+		assert.NoError(err)
+
+		n, err := scanners.LocalScan("7185212994")
+		assert.NoError(err)
+
+		results := &scanners.ScanResult{
+			Local: n,
+		}
+
+		err = c.CacheResults(results)
+		assert.NoError(err)
+
+		cachedResults, err := c.GetResults(n)
+		assert.NoError(err)
+
+		assert.Equal("7185212994", cachedResults.Local.International)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/sundowndev/dorkgen v1.2.0
 	github.com/swaggo/swag v1.6.8
+	go.etcd.io/bbolt v1.3.2
 	gopkg.in/h2non/gock.v1 v1.0.15
 )

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,7 @@ github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.etcd.io/bbolt v1.3.2 h1:Z/90sZLPOeCy2PwprqkFa25PdkusRzaj9P8zm/KNyvk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -7,6 +7,14 @@ import (
 	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
 )
 
+// ScanResult represents all scan results about a number
+type ScanResult struct {
+	Local        *Number                   `json:"local"`
+	GoogleSearch *GoogleSearchResponse     `json:"google_search"`
+	Numverify    *NumverifyScannerResponse `json:"numverify"`
+	OVH          *OVHScannerResponse       `json:"ovh"`
+}
+
 // Number is a phone number
 type Number struct {
 	RawLocal      string `json:"rawLocal"`


### PR DESCRIPTION
### Example

1. Start the scan

`POST /numbers/scan`
`{"input": "+33xxxxxxxx"}`

```
HTTP 201

{"success": true, "uuid": "dda25ad9-8b6d-4c76-a5d2-a6e92e288c1d"}
```

2. Poll on current scan status until it succeed or fail

`GET /numbers/scan/dda25ad9-8b6d-4c76-a5d2-a6e92e288c1d`
```
HTTP 206

{"status": "Busy", "fromCache": false, "input": "+33xxxxxxxx", "scanners": {"local": {}, "numverify": null, "google": {}, "ovh": {}}}
```

`GET /numbers/scan/dda25ad9-8b6d-4c76-a5d2-a6e92e288c1d`
```
HTTP 200

{"status": "Success", "fromCache": true, "input": "+33xxxxxxxx", "scanners": {"local": {}, "numverify": null, "google": {}, "ovh": {}}}
```