### PR TITLE
fix(docker): add missing deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,15 @@ WORKDIR /app
 
 COPY ./client .
 
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache \
+      g++ \
+      make \
+      python3 && \
+  ln -sf python3 /usr/bin/python && \
+  python3 -m ensurepip && \
+  pip3 install --no-cache --upgrade pip setuptools
+
 RUN yarn
 
 RUN yarn build


### PR DESCRIPTION
When building the docker image yarn complained about python, make and g++ missing. Adding these dependencies to the image resulted in a successful built.