### PR TITLE
Added number.Local in combination with facebook searches

### DIFF
--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -234,6 +234,7 @@ func TestGoogleSearchScan(t *testing.T) {
 					Number: "+33673421322",
 					Dork:   "site:smslive.co intext:\"33673421322\" OR intext:\"0673421322\"",
 					URL:    "https://www.google.com/search?q=site%3Asmslive.co+intext%3A%2233673421322%22+OR+intext%3A%220673421322%22",
+
 				},
 			}
 
@@ -278,8 +279,8 @@ func TestGoogleSearchScan(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
 					Number: "+33673421322",
-					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\" OR intext:\"0673421322\" OR intext:\"06.73.42.13.22\"",
-					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%220673421322%22+OR+intext%3A%2206.73.42.13.22%22",
+					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\" OR intext:\"06 73 42 13 22\" OR intext:\"0673421322\" OR intext:\"06.73.42.13.22\"",
+					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%2206+73+42+13+22%22+OR+intext%3A%220673421322%22+OR+intext%3A%2206.73.42.13.22%22",
 				},
 				{
 					Number: "+33673421322",

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -247,8 +247,8 @@ func TestGoogleSearchScan(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
 					Number: "+33673421322",
-					Dork:   `site:facebook.com intext:"33673421322" OR intext:"+33673421322" OR intext:"06 73 42 13 22" OR intext:"0673421322"`,
-					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%2206+73+42+13+22%22+OR+intext%3A%220673421322%22",
+					Dork:   "site:facebook.com intext:\"33365179268\" OR intext:\"+33365179268\" OR intext:\"0365179268\"",
+					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233365179268%22+OR+intext%3A%22%2B33365179268%22+OR+intext%3A%220365179268%22",
 				},
 				{
 					Number: "+33673421322",

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -246,7 +246,7 @@ func TestGoogleSearchScan(t *testing.T) {
 		t.Run("should generate social media dorks", func(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
-					Number: "+33673421322",
+					Number: "+33365179268",
 					Dork:   "site:facebook.com intext:\"33365179268\" OR intext:\"+33365179268\" OR intext:\"0365179268\"",
 					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233365179268%22+OR+intext%3A%22%2B33365179268%22+OR+intext%3A%220365179268%22",
 				},

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -246,7 +246,7 @@ func TestGoogleSearchScan(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
 					Number: "+33673421322",
-					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\"  OR intext:\"06 73 42 13 22\" OR intext:\"0673421322\"",
+					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\" OR intext:\"06 73 42 13 22\" OR intext:\"0673421322\"",
 					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%2206+73+42+13+22%22+OR+intext%3A%220673421322%22",
 				},
 				{

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -246,7 +246,7 @@ func TestGoogleSearchScan(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
 					Number: "+33673421322",
-					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\" OR intext:\"06 73 42 13 22\" OR intext:\"0673421322\"",
+					Dork:   `site:facebook.com intext:"33673421322" OR intext:"+33673421322" OR intext:"06 73 42 13 22" OR intext:"0673421322"`,
 					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%2206+73+42+13+22%22+OR+intext%3A%220673421322%22",
 				},
 				{

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -246,8 +246,8 @@ func TestGoogleSearchScan(t *testing.T) {
 			expectedResult := []*GoogleSearchDork{
 				{
 					Number: "+33673421322",
-					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\" OR intext:\"0673421322\"",
-					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%220673421322%22",
+					Dork:   "site:facebook.com intext:\"33673421322\" OR intext:\"+33673421322\"  OR intext:\"06 73 42 13 22\" OR intext:\"0673421322\"",
+					URL:    "https://www.google.com/search?q=site%3Afacebook.com+intext%3A%2233673421322%22+OR+intext%3A%22%2B33673421322%22+OR+intext%3A%2206+73+42+13+22%22+OR+intext%3A%220673421322%22",
 				},
 				{
 					Number: "+33673421322",


### PR DESCRIPTION
Facebook Pages (businesses, etc) in the US will not return any results with `RawLocal` formatting -- it requires `(000) 000-0000` Local formatting to get best results.