### PR TITLE
Validator to return explicit error

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -83,7 +83,7 @@ func TestApi(t *testing.T) {
 
 				assert.Equal(err, nil, "should be equal")
 				assert.Equal(res.Result().StatusCode, 400, "should be equal")
-				assert.Equal(string(body), "{\"success\":false,\"error\":\"Parameter 'number' must be a valid integer.\"}", "should be equal")
+				assert.Equal( "{\"success\":false,\"error\":\"strconv.ParseUint: parsing \\\"azerty\\\": invalid syntax\"}", string(body))
 			})
 
 			t.Run("invalid country code", func(t *testing.T) {

--- a/api/validators.go
+++ b/api/validators.go
@@ -22,7 +22,7 @@ func ValidateScanURL(c *gin.Context) {
 	var v scanURL
 
 	if err := c.ShouldBindUri(&v); err != nil {
-		errorHandling(c, "Parameter 'number' must be a valid integer.")
+		errorHandling(c, err.Error())
 		return
 	}
 


### PR DESCRIPTION
As discussed in #725 , some users may receive unexpected `Parameter 'number' must be a valid integer` error when launching a scan with a valid phone number. 