### PR TITLE
Handle Numverify rate limit errors

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -83,7 +83,7 @@ func TestApi(t *testing.T) {
 
 				assert.Equal(err, nil, "should be equal")
 				assert.Equal(res.Result().StatusCode, 400, "should be equal")
-				assert.Equal( "{\"success\":false,\"error\":\"strconv.ParseUint: parsing \\\"azerty\\\": invalid syntax\"}", string(body))
+				assert.Equal("{\"success\":false,\"error\":\"strconv.ParseUint: parsing \\\"azerty\\\": invalid syntax\"}", string(body))
 			})
 
 			t.Run("invalid country code", func(t *testing.T) {
@@ -153,7 +153,7 @@ func TestApi(t *testing.T) {
 
 				assert.Equal(err, nil, "should be equal")
 				assert.Equal(res.Result().StatusCode, 200, "should be equal")
-				assert.Equal(string(body), `{"success":true,"error":"","result":{"valid":true,"number":"79516566591","local_format":"9516566591","international_format":"+79516566591","country_prefix":"+7","country_code":"RU","country_name":"Russian Federation","location":"Saint Petersburg and Leningrad Oblast","carrier":"OJSC St. Petersburg Telecom (OJSC Tele2-Saint-Petersburg)","line_type":"mobile"}}`, "should be equal")
+				assert.Equal(string(body), `{"success":true,"error":"","result":{"valid":true,"number":"79516566591","local_format":"9516566591","international_format":"+79516566591","country_prefix":"+7","country_code":"RU","country_name":"Russian Federation","location":"Saint Petersburg and Leningrad Oblast","carrier":"OJSC St. Petersburg Telecom (OJSC Tele2-Saint-Petersburg)","line_type":"mobile","error":{"code":0,"info":""}}}`, "should be equal")
 
 				assert.Equal(gock.IsDone(), true, "there should have no pending mocks")
 			})

--- a/scanners/numverify.go
+++ b/scanners/numverify.go
@@ -10,18 +10,24 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
+type numverifyError struct {
+	Code int    `json:"code"`
+	Info string `json:"info"`
+}
+
 // NumverifyScannerResponse REST API response
 type NumverifyScannerResponse struct {
-	Valid               bool   `json:"valid"`
-	Number              string `json:"number"`
-	LocalFormat         string `json:"local_format"`
-	InternationalFormat string `json:"international_format"`
-	CountryPrefix       string `json:"country_prefix"`
-	CountryCode         string `json:"country_code"`
-	CountryName         string `json:"country_name"`
-	Location            string `json:"location"`
-	Carrier             string `json:"carrier"`
-	LineType            string `json:"line_type"`
+	Valid               bool           `json:"valid"`
+	Number              string         `json:"number"`
+	LocalFormat         string         `json:"local_format"`
+	InternationalFormat string         `json:"international_format"`
+	CountryPrefix       string         `json:"country_prefix"`
+	CountryCode         string         `json:"country_code"`
+	CountryName         string         `json:"country_name"`
+	Location            string         `json:"location"`
+	Carrier             string         `json:"carrier"`
+	LineType            string         `json:"line_type"`
+	Error               numverifyError `json:"error"`
 }
 
 // NumverifyScan fetches Numverify's API
@@ -59,6 +65,10 @@ func NumverifyScan(number *Number) (res *NumverifyScannerResponse, err error) {
 	// Use json.Decode for reading streams of JSON data
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return nil, err
+	}
+
+	if len(result.Error.Info) > 0 {
+		return nil, fmt.Errorf("the Numverify API returned an error: %v", result.Error.Info)
 	}
 
 	res = &NumverifyScannerResponse{


### PR DESCRIPTION
Numverify API often returns rate limit errors which are not handled properly and cause confusion for the end user.

Related issues: #904 #902  #861 #826 #865