### PR TITLE
chore(deps): bump node from 15.11.0-alpine to 17.0.1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.11.0-alpine AS client_builder
+FROM node:17.0.1-alpine AS client_builder
 
 WORKDIR /app
 


### PR DESCRIPTION
> Bumps node from 15.11.0-alpine to 17.0.1-alpine.

---
updated-dependencies:
- dependency-name: node
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>