### PR TITLE
Rename go module path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     - amd64
     - arm
     - arm64
-  ldflags: -s -w -X gopkg.in/sundowndev/phoneinfoga.v2/config.Version={{.Version}} -X gopkg.in/sundowndev/phoneinfoga.v2/config.Commit={{.ShortCommit}}
+  ldflags: -s -w -X github.com/sundowndev/phoneinfoga/v2/config.Version={{.Version}} -X github.com/sundowndev/phoneinfoga/v2/config.Commit={{.ShortCommit}}
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   replacements:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=client_builder /app/dist ./client/dist
 
 RUN go generate ./...
 
-RUN go build -v -ldflags="-s -w -X 'gopkg.in/sundowndev/phoneinfoga.v2/config.Version=$(git describe --abbrev=0 --tags)' -X 'gopkg.in/sundowndev/phoneinfoga.v2/config.Commit=$(git rev-parse --short HEAD)'" -v -o phoneinfoga .
+RUN go build -v -ldflags="-s -w -X 'github.com/sundowndev/phoneinfoga/v2/config.Version=$(git describe --abbrev=0 --tags)' -X 'github.com/sundowndev/phoneinfoga/v2/config.Commit=$(git rev-parse --short HEAD)'" -v -o phoneinfoga .
 
 FROM golang:1.17.5-alpine
 

--- a/api/controllers.go
+++ b/api/controllers.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
-	"gopkg.in/sundowndev/phoneinfoga.v2/config"
-	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
+	"github.com/sundowndev/phoneinfoga/v2/config"
+	"github.com/sundowndev/phoneinfoga/v2/scanners"
 )
 
 type scanResultResponse struct {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -307,6 +307,9 @@ var doc = `{
                 "error": {
                     "type": "string"
                 },
+                "message": {
+                    "type": "string"
+                },
                 "success": {
                     "type": "boolean"
                 }
@@ -316,6 +319,9 @@ var doc = `{
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "numbers": {
@@ -347,6 +353,9 @@ var doc = `{
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "result": {
@@ -447,6 +456,9 @@ var doc = `{
                 "country_prefix": {
                     "type": "string"
                 },
+                "error": {
+                    "$ref": "#/definitions/scanners.numverifyError"
+                },
                 "international_format": {
                     "type": "string"
                 },
@@ -480,6 +492,17 @@ var doc = `{
                     "type": "string"
                 },
                 "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "scanners.numverifyError": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "info": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -296,6 +296,9 @@
                 "error": {
                     "type": "string"
                 },
+                "message": {
+                    "type": "string"
+                },
                 "success": {
                     "type": "boolean"
                 }
@@ -305,6 +308,9 @@
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "numbers": {
@@ -336,6 +342,9 @@
             "type": "object",
             "properties": {
                 "error": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "result": {
@@ -436,6 +445,9 @@
                 "country_prefix": {
                     "type": "string"
                 },
+                "error": {
+                    "$ref": "#/definitions/scanners.numverifyError"
+                },
                 "international_format": {
                     "type": "string"
                 },
@@ -469,6 +481,17 @@
                     "type": "string"
                 },
                 "zipCode": {
+                    "type": "string"
+                }
+            }
+        },
+        "scanners.numverifyError": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "info": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -4,12 +4,16 @@ definitions:
     properties:
       error:
         type: string
+      message:
+        type: string
       success:
         type: boolean
     type: object
   api.getAllNumbersResponse:
     properties:
       error:
+        type: string
+      message:
         type: string
       numbers:
         items:
@@ -30,6 +34,8 @@ definitions:
   api.scanResultResponse:
     properties:
       error:
+        type: string
+      message:
         type: string
       result:
         type: object
@@ -95,6 +101,8 @@ definitions:
         type: string
       country_prefix:
         type: string
+      error:
+        $ref: '#/definitions/scanners.numverifyError'
       international_format:
         type: string
       line_type:
@@ -117,6 +125,13 @@ definitions:
       numberRange:
         type: string
       zipCode:
+        type: string
+    type: object
+  scanners.numverifyError:
+    properties:
+      code:
+        type: integer
+      info:
         type: string
     type: object
 host: demo.phoneinfoga.crvx.fr

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/sundowndev/phoneinfoga/v2/scanners"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 	assertTest "github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
-	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
 )
 
 var r *gin.Engine

--- a/api/validators.go
+++ b/api/validators.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
+	"github.com/sundowndev/phoneinfoga/v2/scanners"
 )
 
 // JSONResponse is the default API response type

--- a/cmd/recon.go
+++ b/cmd/recon.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 func init() {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -4,8 +4,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/sundowndev/phoneinfoga.v2/scanners"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/scanners"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 func init() {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
-	api "gopkg.in/sundowndev/phoneinfoga.v2/api"
+	"github.com/sundowndev/phoneinfoga/v2/api"
 )
 
 var httpPort int

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"gopkg.in/sundowndev/phoneinfoga.v2/config"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/config"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 func init() {

--- a/docs/go-module-usage.md
+++ b/docs/go-module-usage.md
@@ -1,11 +1,11 @@
 # Go module usage
 
-You can easily use scanners in your own Golang script. You can find [Go documentation here](https://pkg.go.dev/gopkg.in/sundowndev/phoneinfoga.v2).
+You can easily use scanners in your own Golang script. You can find [Go documentation here](https://pkg.go.dev/github.com/sundowndev/phoneinfoga/v2).
 
 ### Install the module
 
 ```
-go get -v gopkg.in/sundowndev/phoneinfoga.v2
+go get -v github.com/sundowndev/phoneinfoga/v2
 ```
 
 ### Usage example
@@ -17,17 +17,17 @@ import (
 	"fmt"
 	"log"
 
-	phoneinfoga "gopkg.in/sundowndev/phoneinfoga.v2/pkg/scanners"
+	"github.com/sundowndev/phoneinfoga/v2/pkg/scanners"
 )
 
 func main() {
-	number, err := phoneinfoga.LocalScan("<number>")
+	number, err := scanners.LocalScan("<number>")
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	links := phoneinfoga.GoogleSearchScan(number)
+	links := scanners.GoogleSearchScan(number)
 
 	for _, link := range links.Individuals {
 		fmt.Println(link.URL) // Google search link to scan

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gopkg.in/sundowndev/phoneinfoga.v2
+module github.com/sundowndev/phoneinfoga/v2
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"gopkg.in/sundowndev/phoneinfoga.v2/cmd"
+	"github.com/sundowndev/phoneinfoga/v2/cmd"
 )
 
 func main() {

--- a/scanners/google_test.go
+++ b/scanners/google_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	assertTest "github.com/stretchr/testify/assert"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 func TestGoogleSearchScan(t *testing.T) {

--- a/scanners/local.go
+++ b/scanners/local.go
@@ -2,7 +2,7 @@ package scanners
 
 import (
 	"github.com/nyaruka/phonenumbers"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 // LocalScan performs a local scan of a phone

--- a/scanners/local_test.go
+++ b/scanners/local_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	assertion "github.com/stretchr/testify/assert"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 func TestLocalScan(t *testing.T) {

--- a/scanners/numverify_test.go
+++ b/scanners/numverify_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	assertion "github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 	gock "gopkg.in/h2non/gock.v1"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
 )
 
 func TestNumverifyScanner(t *testing.T) {

--- a/scanners/ovh_test.go
+++ b/scanners/ovh_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	assertion "github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 	gock "gopkg.in/h2non/gock.v1"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
 )
 
 func TestOVHScanner(t *testing.T) {

--- a/scanners/scanners.go
+++ b/scanners/scanners.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils"
+	"github.com/sundowndev/phoneinfoga/v2/utils"
 )
 
 // Number is a phone number

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fatih/color"
 	assertion "github.com/stretchr/testify/assert"
-	"gopkg.in/sundowndev/phoneinfoga.v2/utils/mocks"
+	"github.com/sundowndev/phoneinfoga/v2/utils/mocks"
 )
 
 func TestUtils(t *testing.T) {


### PR DESCRIPTION
- Rename the Go module path to `github.com/sundowndev/phoneinfoga/v2`
- Update swagger definitions
- Creates empty bin directory for build artifacts 