### PR TITLE
Limit OVH scan to specific country codes

### DIFF
--- a/lib/remote/ovh_scanner.go
+++ b/lib/remote/ovh_scanner.go
@@ -32,6 +32,10 @@ func (s *ovhScanner) ShouldRun() bool {
 }
 
 func (s *ovhScanner) Scan(n *number.Number) (interface{}, error) {
+	if !s.isSupported(n.CountryCode) {
+		return nil, nil
+	}
+
 	res, err := s.client.Search(*n)
 	if err != nil {
 		return nil, err
@@ -45,4 +49,19 @@ func (s *ovhScanner) Scan(n *number.Number) (interface{}, error) {
 	}
 
 	return data, nil
+}
+
+func (s *ovhScanner) supportedCountryCodes() []int32 {
+	// See https://api.ovh.com/console/#/telephony/number/detailedZones#GET
+	return []int32{33, 32, 44, 34, 41}
+}
+
+func (s *ovhScanner) isSupported(code int32) bool {
+	supported := false
+	for _, c := range s.supportedCountryCodes() {
+		if code == c {
+			supported = true
+		}
+	}
+	return supported
 }

--- a/lib/remote/ovh_scanner_test.go
+++ b/lib/remote/ovh_scanner_test.go
@@ -12,7 +12,7 @@ import (
 func TestOVHScanner(t *testing.T) {
 	dummyError := errors.New("dummy")
 
-	dummyNumber, _ := number.NewNumber("15556661212")
+	dummyNumber, _ := number.NewNumber("33365174444")
 
 	testcases := []struct {
 		name       string
@@ -50,6 +50,16 @@ func TestOVHScanner(t *testing.T) {
 			wantErrors: map[string]error{
 				"ovh": dummyError,
 			},
+		},
+		{
+			name: "country not supported",
+			number: func() *number.Number {
+				num, _ := number.NewNumber("15556661212")
+				return num
+			}(),
+			mocks:      func(s *mocks.OVHSupplier) {},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{},
 		},
 	}
 

--- a/lib/remote/remote.go
+++ b/lib/remote/remote.go
@@ -31,7 +31,9 @@ func (r *Library) Scan(n *number.Number) (map[string]interface{}, map[string]err
 			errors[name] = err
 			continue
 		}
-		allData[name] = data
+		if data != nil {
+			allData[name] = data
+		}
 	}
 	return allData, errors
 }

--- a/lib/remote/suppliers/ovh.go
+++ b/lib/remote/suppliers/ovh.go
@@ -43,6 +43,10 @@ func NewOVHSupplier() *OVHSupplier {
 func (s *OVHSupplier) Search(num number.Number) (*OVHScannerResponse, error) {
 	countryCode := strings.ToLower(num.Country)
 
+	if countryCode == "" {
+		return nil, fmt.Errorf("country code +%d wasn't recognized", num.CountryCode)
+	}
+
 	// Build the request
 	response, err := http.Get(fmt.Sprintf("https://api.ovh.com/1.0/telephony/number/detailedZones?country=%s", countryCode))
 	if err != nil {

--- a/lib/remote/suppliers/ovh_test.go
+++ b/lib/remote/suppliers/ovh_test.go
@@ -68,3 +68,15 @@ func TestOVHSupplierError(t *testing.T) {
 		Err: dummyError,
 	}, err)
 }
+
+func TestOVHSupplierCountryCodeError(t *testing.T) {
+	defer gock.Off() // Flush pending mocks after test execution
+
+	num, _ := number.NewNumber("15556661212")
+
+	s := NewOVHSupplier()
+
+	got, err := s.Search(*num)
+	assert.Nil(t, got)
+	assert.EqualError(t, err, "country code +1 wasn't recognized")
+}


### PR DESCRIPTION
This PR adds a list of supported country codes for the OVH scanner so we can skip it when the phone number isn't supported.