### PR TITLE
Update install with docker-compose docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -56,7 +56,7 @@ services:
     phoneinfoga:
       container_name: phoneinfoga
       restart: on-failure
-      image: phoneinfoga:latest
+      image: sundowndev/phoneinfoga:latest
       command:
         - "serve"
       ports:


### PR DESCRIPTION
Change image in docker-compose from phoneinfoga to sundowndev/phoneinfoga.
So that it can be copied completely from the docs site.