### PR TITLE
Update the request for numverify scan

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -141,9 +141,9 @@ func TestApi(t *testing.T) {
 					LineType:            "mobile",
 				}
 
-				gock.New("http://apilayer.net").
-					Get("/api/validate").
-					MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
+				gock.New("http://api.apilayer.com").
+					Get("/number_verification/validate").
+					MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 					MatchParam("number", number).
 					Reply(200).
 					JSON(expectedResult)

--- a/lib/remote/suppliers/numverify.go
+++ b/lib/remote/suppliers/numverify.go
@@ -69,7 +69,7 @@ func (s *NumverifySupplier) Validate(internationalNumber string) (res *Numverify
 	// Build the request
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Set("apikey", s.ApiKey)
+	req.Header.Set("Apikey", s.ApiKey)
 
 	response, err := client.Do(req)
 

--- a/lib/remote/suppliers/numverify.go
+++ b/lib/remote/suppliers/numverify.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 type NumverifySupplierInterface interface {
@@ -62,8 +63,16 @@ func (s *NumverifySupplier) Validate(internationalNumber string) (res *Numverify
 		WithField("scheme", scheme).
 		Debug("Running validate operation through Numverify API")
 
+
+	url := fmt.Sprintf("%s://api.apilayer.com/number_verification/validate?number=%s", scheme, internationalNumber)
+
 	// Build the request
-	response, err := http.Get(fmt.Sprintf("%s://apilayer.net/api/validate?access_key=%s&number=%s", scheme, s.ApiKey, internationalNumber))
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("apikey", s.ApiKey)
+
+	response, err := client.Do(req)
+
 	if err != nil {
 		return nil, err
 	}

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -32,9 +32,9 @@ func TestNumverifySupplierSuccess(t *testing.T) {
 		LineType:            "mobile",
 	}
 
-	gock.New("https://apilayer.net").
-		Get("/api/validate").
-		MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
+	gock.New("https://api.apilayer.com").
+		Get("/number_verification/validate").
+		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(200).
 		JSON(expectedResult)
@@ -70,9 +70,9 @@ func TestNumverifySupplierWithoutSSL(t *testing.T) {
 		LineType:            "mobile",
 	}
 
-	gock.New("http://apilayer.net").
-		Get("/api/validate").
-		MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
+	gock.New("http://api.apilayer.com").
+		Get("/number_verification/validate").
+		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(200).
 		JSON(expectedResult)
@@ -103,9 +103,9 @@ func TestNumverifySupplierError(t *testing.T) {
 		},
 	}
 
-	gock.New("http://apilayer.net").
-		Get("/api/validate").
-		MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
+	gock.New("http://api.apilayer.com").
+		Get("/number_verification/validate").
+		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(400).
 		JSON(expectedResult)
@@ -131,8 +131,8 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 
 	dummyError := errors.New("test")
 
-	gock.New("https://apilayer.net").
-		Get("/api/validate").
+	gock.New("https://api.apilayer.com").
+		Get("/number_verification/validate").
 		ReplyError(dummyError)
 
 	s := NewNumverifySupplier()
@@ -143,7 +143,7 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 	assert.Nil(t, got)
 	assert.Equal(t, &url.Error{
 		Op:  "Get",
-		URL: "https://apilayer.net/api/validate?access_key=5ad5554ac240e4d3d31107941b35a5eb&number=11115551212",
+		URL: "https://api.apilayer.com/number_verification/validate?&number=11115551212",
 		Err: dummyError,
 	}, err)
 }

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -143,7 +143,7 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 	assert.Nil(t, got)
 	assert.Equal(t, &url.Error{
 		Op:  "Get",
-		URL: "https://api.apilayer.com/number_verification/validate?&number=11115551212",
+		URL: "https://api.apilayer.com/number_verification/validate?number=11115551212",
 		Err: dummyError,
 	}, err)
 }

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -34,7 +34,7 @@ func TestNumverifySupplierSuccess(t *testing.T) {
 
 	gock.New("https://api.apilayer.com").
 		Get("/number_verification/validate").
-		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
+		MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(200).
 		JSON(expectedResult)
@@ -72,7 +72,7 @@ func TestNumverifySupplierWithoutSSL(t *testing.T) {
 
 	gock.New("http://api.apilayer.com").
 		Get("/number_verification/validate").
-		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
+		MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(200).
 		JSON(expectedResult)
@@ -105,7 +105,7 @@ func TestNumverifySupplierError(t *testing.T) {
 
 	gock.New("http://api.apilayer.com").
 		Get("/number_verification/validate").
-		MatchHeader("apikey", "5ad5554ac240e4d3d31107941b35a5eb").
+		MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
 		Reply(400).
 		JSON(expectedResult)


### PR DESCRIPTION
Previously, the API endpoint to perform a numverify scan was as follows.
```javascript
GET https://apilayer.net/api/validate?access_key=access_key&number=phone_number
```

This has been changed to the following.
```javascript
GET https://api.apilayer.com/number_verification/validate?number=phone_number
apikey: access_key
```
I still don't know why the previous endpoint gets a hit and returns a response but doesn't do the verification job. The following is the screenshot after making the change. No automation tests are run.

Resolves #1056 

![image](https://user-images.githubusercontent.com/24423580/173191170-5f00ba33-83e5-4199-a0b7-9a551ca6e243.png)

