### PR TITLE
Fix numverify scanner

### DIFF
--- a/docs/getting-started/scanners.md
+++ b/docs/getting-started/scanners.md
@@ -40,12 +40,17 @@ The local scan is probably the simplest scan of PhoneInfoga. By default, the too
 
 Numverify provide standard but useful information such as country code, location, line type and carrier. This scanners requires an API-key which you can get on their website after creating an account. You can use a free API key as long as you don't exceed the monthly quota.
 
+[Read documentation](https://apilayer.com/marketplace/number_verification-api#details-tab)
+
 ??? info "Configuration"
+
+    1. Go to the [Api layer website](https://apilayer.com/) and create an account
+    2. Go to "Number Verification API" in the marketplace, click on "Subscribe for free", then choose whatever plan you want
+    3. Copy the new API token and use it as an environment variable
 
     | Environment variable | Default | Description                                                            |
     |----------------------|---------|------------------------------------------------------------------------|
     | NUMVERIFY_API_KEY    |         | API key to authenticate to the Numverify API.                          |
-    | NUMVERIFY_ENABLE_SSL | false   | Whether to use HTTPS or plain HTTP for requests to the Numverify API.  |
 
 ??? example "Output example"
 
@@ -60,7 +65,6 @@ Numverify provide standard but useful information such as country code, location
     Country prefix: +41
     Country code: CH
     Country name: Switzerland (Confederation of)
-    Location:
     Carrier: Sunrise Communications AG
     Line type: mobile
     ```

--- a/lib/remote/numverify_scanner.go
+++ b/lib/remote/numverify_scanner.go
@@ -13,15 +13,15 @@ type numverifyScanner struct {
 
 type NumverifyScannerResponse struct {
 	Valid               bool   `json:"valid" console:"Valid"`
-	Number              string `json:"number" console:"Number"`
-	LocalFormat         string `json:"local_format" console:"Local format"`
-	InternationalFormat string `json:"international_format" console:"International format"`
-	CountryPrefix       string `json:"country_prefix" console:"Country prefix"`
-	CountryCode         string `json:"country_code" console:"Country code"`
-	CountryName         string `json:"country_name" console:"Country name"`
-	Location            string `json:"location" console:"Location"`
-	Carrier             string `json:"carrier" console:"Carrier"`
-	LineType            string `json:"line_type" console:"Line type"`
+	Number              string `json:"number" console:"Number,omitempty"`
+	LocalFormat         string `json:"local_format" console:"Local format,omitempty"`
+	InternationalFormat string `json:"international_format" console:"International format,omitempty"`
+	CountryPrefix       string `json:"country_prefix" console:"Country prefix,omitempty"`
+	CountryCode         string `json:"country_code" console:"Country code,omitempty"`
+	CountryName         string `json:"country_name" console:"Country name,omitempty"`
+	Location            string `json:"location" console:"Location,omitempty"`
+	Carrier             string `json:"carrier" console:"Carrier,omitempty"`
+	LineType            string `json:"line_type" console:"Line type,omitempty"`
 }
 
 func NewNumverifyScanner(s suppliers.NumverifySupplierInterface) Scanner {

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -15,9 +15,7 @@ func TestNumverifySupplierSuccess(t *testing.T) {
 	number := "11115551212"
 
 	_ = os.Setenv("NUMVERIFY_API_KEY", "5ad5554ac240e4d3d31107941b35a5eb")
-	_ = os.Setenv("NUMVERIFY_ENABLE_SSL", "1")
-	defer os.Setenv("NUMVERIFY_API_KEY", "")
-	defer os.Setenv("NUMVERIFY_ENABLE_SSL", "")
+	defer os.Clearenv()
 
 	expectedResult := &NumverifyValidateResponse{
 		Valid:               true,
@@ -49,65 +47,23 @@ func TestNumverifySupplierSuccess(t *testing.T) {
 	assert.Equal(t, expectedResult, got)
 }
 
-func TestNumverifySupplierWithoutSSL(t *testing.T) {
-	defer gock.Off() // Flush pending mocks after test execution
-
-	number := "11115551212"
-
-	_ = os.Setenv("NUMVERIFY_API_KEY", "5ad5554ac240e4d3d31107941b35a5eb")
-	defer os.Setenv("NUMVERIFY_API_KEY", "")
-
-	expectedResult := &NumverifyValidateResponse{
-		Valid:               true,
-		Number:              "79516566591",
-		LocalFormat:         "9516566591",
-		InternationalFormat: "+79516566591",
-		CountryPrefix:       "+7",
-		CountryCode:         "RU",
-		CountryName:         "Russian Federation",
-		Location:            "Saint Petersburg and Leningrad Oblast",
-		Carrier:             "OJSC St. Petersburg Telecom (OJSC Tele2-Saint-Petersburg)",
-		LineType:            "mobile",
-	}
-
-	gock.New("http://api.apilayer.com").
-		Get("/number_verification/validate").
-		MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
-		MatchParam("number", number).
-		Reply(200).
-		JSON(expectedResult)
-
-	s := NewNumverifySupplier()
-
-	assert.True(t, s.IsAvailable())
-
-	got, err := s.Validate(number)
-	assert.Nil(t, err)
-
-	assert.Equal(t, expectedResult, got)
-}
-
 func TestNumverifySupplierError(t *testing.T) {
 	defer gock.Off() // Flush pending mocks after test execution
 
 	number := "11115551212"
 
 	_ = os.Setenv("NUMVERIFY_API_KEY", "5ad5554ac240e4d3d31107941b35a5eb")
-	defer os.Setenv("NUMVERIFY_API_KEY", "")
+	defer os.Clearenv()
 
-	expectedResult := &NumverifyValidateResponse{
-		Valid: false,
-		Error: numverifyError{
-			Code: 100,
-			Info: "Access Restricted - Your current Subscription Plan does not support HTTPS Encryption.",
-		},
+	expectedResult := &NumverifyErrorResponse{
+		Message: "You have exceeded your daily\\/monthly API rate limit. Please review and upgrade your subscription plan at https:\\/\\/apilayer.com\\/subscriptions to continue.",
 	}
 
-	gock.New("http://api.apilayer.com").
+	gock.New("https://api.apilayer.com").
 		Get("/number_verification/validate").
 		MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
 		MatchParam("number", number).
-		Reply(400).
+		Reply(429).
 		JSON(expectedResult)
 
 	s := NewNumverifySupplier()
@@ -116,7 +72,7 @@ func TestNumverifySupplierError(t *testing.T) {
 
 	got, err := s.Validate(number)
 	assert.Nil(t, got)
-	assert.Equal(t, errors.New("Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."), err)
+	assert.Equal(t, errors.New("You have exceeded your daily\\/monthly API rate limit. Please review and upgrade your subscription plan at https:\\/\\/apilayer.com\\/subscriptions to continue."), err)
 }
 
 func TestNumverifySupplierHTTPError(t *testing.T) {
@@ -125,9 +81,7 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 	number := "11115551212"
 
 	_ = os.Setenv("NUMVERIFY_API_KEY", "5ad5554ac240e4d3d31107941b35a5eb")
-	_ = os.Setenv("NUMVERIFY_ENABLE_SSL", "1")
-	defer os.Setenv("NUMVERIFY_API_KEY", "")
-	defer os.Setenv("NUMVERIFY_ENABLE_SSL", "")
+	defer os.Clearenv()
 
 	dummyError := errors.New("test")
 


### PR DESCRIPTION
- Remove SSL option since it must always be enabled
- Hide empty fields in console output
- Improve scanner documentation
- Improve error handling, auth errors were hidden to the user, always showing that it's an invalid phone number