### PR TITLE
Enable building for armv7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,9 @@ builds:
     - amd64
     - arm
     - arm64
+  goarm:
+    - 6
+    - 7
   ldflags: -s -w -X github.com/sundowndev/phoneinfoga/v2/build.Version={{.Version}} -X github.com/sundowndev/phoneinfoga/v2/build.Commit={{.ShortCommit}}
 archives:
 - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'


### PR DESCRIPTION
Note this does not affect the Docker builds.

Related to https://github.com/sundowndev/phoneinfoga/pull/1137