### PR TITLE
Add error to printed message when plugin fails to open

### DIFF
--- a/lib/remote/scanner.go
+++ b/lib/remote/scanner.go
@@ -2,9 +2,10 @@ package remote
 
 import (
 	"fmt"
-	"github.com/sundowndev/phoneinfoga/v2/lib/number"
 	"os"
 	"plugin"
+
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
 )
 
 type Plugin interface {
@@ -25,7 +26,7 @@ func OpenPlugin(path string) error {
 
 	_, err := plugin.Open(path)
 	if err != nil {
-		return fmt.Errorf("given plugin %s is not valid", path)
+		return fmt.Errorf("given plugin %s is not valid: %v", path, err)
 	}
 
 	return nil

--- a/lib/remote/scanner_test.go
+++ b/lib/remote/scanner_test.go
@@ -1,11 +1,19 @@
 package remote
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ValidatePlugin_Errors(t *testing.T) {
+	invalidPluginAbsPath, err := filepath.Abs("testdata/invalid.so")
+	if err != nil {
+		assert.FailNow(t, "failed to get the absolute path of test file: %v", err)
+	}
+
 	testcases := []struct {
 		name    string
 		path    string
@@ -19,7 +27,7 @@ func Test_ValidatePlugin_Errors(t *testing.T) {
 		{
 			name:    "test with invalid plugin",
 			path:    "testdata/invalid.so",
-			wantErr: "given plugin testdata/invalid.so is not valid",
+			wantErr: fmt.Sprintf("given plugin testdata/invalid.so is not valid: plugin.Open(\"testdata/invalid.so\"): %s: file too short", invalidPluginAbsPath),
 		},
 	}
 


### PR DESCRIPTION
When a plugin fails to open, print the error from the open call to aid in debugging why your custom scanner wont work.