### PR TITLE
Add homebrew workflow

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,12 @@
+name: Homebrew Bump Formula
+on:
+  release:
+    types: [published]
+jobs:
+  homebrew:
+    runs-on: macos-latest
+    steps:
+      - uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          formula: phoneinfoga

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,14 @@ clean:
 
 .PHONY: lint
 lint:
-	@which golangci-lint > /dev/null 2>&1 || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(GOBINPATH) v1.46.2)
-	golangci-lint run -v --timeout=10m
+	golangci-lint run -v --timeout=2m
 
 .PHONY: install-tools
 install-tools:
 	$(GOINSTALL) gotest.tools/gotestsum@v1.6.3
 	$(GOINSTALL) github.com/vektra/mockery/v2@v2.8.0
 	$(GOINSTALL) github.com/swaggo/swag/cmd/swag@v1.7.0
+	@which golangci-lint > /dev/null 2>&1 || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(GOBINPATH) v1.46.2)
 
 go.mod: FORCE
 	$(GOMOD) tidy

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -13,14 +13,14 @@ Follow the instructions :
 
 You can also do it from the terminal (UNIX systems only) :
 
-1. Download latest release in the current directory
+1. Download the latest release in the current directory
 
 ```
 # Add --help at the end of the command for a list of install options
 bash <( curl -sSL https://raw.githubusercontent.com/sundowndev/phoneinfoga/master/support/scripts/install )
 ```
 
-2. Install phoneinfoga
+2. Install it globally
 ```
 sudo install ./phoneinfoga /usr/local/bin/phoneinfoga
 ```
@@ -32,7 +32,15 @@ sudo install ./phoneinfoga /usr/local/bin/phoneinfoga
 
 To ensure your system is supported, please check the output of `echo "$(uname -s)_$(uname -m)"` in your terminal and see if it's available on the [GitHub release page](https://github.com/sundowndev/phoneinfoga/releases).
 
-## Using Docker
+## Homebrew
+
+PhoneInfoga is now available on Homebrew. Homebrew is a free and open-source package management system for Mac OS X. Install the official phoneinfoga formula from the terminal.
+
+```shell
+brew install phoneinfoga
+```
+
+## Docker
 
 !!! info
     If you want to use the beta channel, you can use the `next` tag, it's updated directly from the master branch. But in most cases we recommend using [`latest`, `v2` or `stable` tags](https://hub.docker.com/r/sundowndev/phoneinfoga/tags) to only get release updates.
@@ -69,7 +77,7 @@ services:
         - "80:5000"
 ```
 
-### From the source code
+### Build from source
 
 You can download the source code, then build the docker images
 


### PR DESCRIPTION
*Maintainers should watch https://github.com/Homebrew/homebrew-core/pull/123195 first*

----

This PR adds a new CI workflow for updating Phoneinfoga in the Homebrew package repository. It also adds some documentation about homebrew installation.