### PR TITLE
Update api apilayer

### DIFF
--- a/lib/remote/suppliers/numverify.go
+++ b/lib/remote/suppliers/numverify.go
@@ -64,7 +64,7 @@ func (r *NumverifyRequest) ValidateNumber(internationalNumber string) (res *Numv
 		WithField("number", internationalNumber).
 		Debug("Running validate operation through Numverify API")
 
-	url := fmt.Sprintf("%s/number_verification/validate?number=%s", r.uri, internationalNumber)
+	url := fmt.Sprintf("%s/api/validate?number=%s", r.uri, internationalNumber)
 
 	// Build the request
 	client := &http.Client{}

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -29,8 +29,8 @@ func TestNumverifySupplierSuccessCustomApiKey(t *testing.T) {
 	}
 
 	gock.New("https://api.apilayer.com").
-		Get("/number_verification/validate").
-		MatchHeader("Apikey", apikey).
+		Get("/api/validate").
+		MatchParam("access_key", apikey).
 		MatchParam("number", number).
 		Reply(200).
 		JSON(expectedResult)
@@ -54,8 +54,8 @@ func TestNumverifySupplierError(t *testing.T) {
 	}
 
 	gock.New("https://api.apilayer.com").
-		Get("/number_verification/validate").
-		MatchHeader("Apikey", apikey).
+		Get("/api/validate").
+		MatchParam("access_key", apikey).
 		MatchParam("number", number).
 		Reply(429).
 		JSON(expectedResult)
@@ -78,7 +78,7 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 	dummyError := errors.New("test")
 
 	gock.New("https://api.apilayer.com").
-		Get("/number_verification/validate").
+		Get("/api/validate").
 		ReplyError(dummyError)
 
 	s := NewNumverifySupplier()
@@ -87,7 +87,7 @@ func TestNumverifySupplierHTTPError(t *testing.T) {
 	assert.Nil(t, got)
 	assert.Equal(t, &url.Error{
 		Op:  "Get",
-		URL: "https://api.apilayer.com/number_verification/validate?number=11115551212",
+		URL: "https://api.apilayer.com/api/validate?number=11115551212",
 		Err: dummyError,
 	}, err)
 }

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -142,8 +142,8 @@ func TestApi(t *testing.T) {
 				}
 
 				gock.New("https://api.apilayer.com").
-					Get("/number_verification/validate").
-					MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
+					Get("/api/validate").
+					MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
 					MatchParam("number", number).
 					Reply(200).
 					JSON(expectedResult)
@@ -173,8 +173,8 @@ func TestApi(t *testing.T) {
 				}
 
 				gock.New("https://api.apilayer.com").
-					Get("/number_verification/validate").
-					MatchHeader("Apikey", "5ad5554ac240e4d3d31107941b35a5eb").
+					Get("/api/validate").
+					MatchParam("access_key", "5ad5554ac240e4d3d31107941b35a5eb").
 					MatchParam("number", number).
 					Reply(429).
 					JSON(expectedResult)


### PR DESCRIPTION
https://blog.apilayer.com/how-to-create-a-phone-number-verification-web-app-using-node-js/#Review_the_Endpoint

The api endpoint now looks like
```
http://apilayer.net/api/validate
 
    ? access_key = ACCESS_KEY
    & number = 14158586273
    & country_code = 
    & format = 1
```

I did not test the patch yet, i'll do it when i have time.