### PR TITLE
chore(deps): bump alpine from 3.18 to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN go get -v -t -d ./...
 RUN make install-tools
 RUN make build
 
-FROM alpine:3.18
+FROM alpine:3.22
 COPY --from=go_builder /app/bin/phoneinfoga /app/phoneinfoga
 EXPOSE 5000
 ENTRYPOINT ["/app/phoneinfoga"]


### PR DESCRIPTION
Bumps alpine from 3.18 to 3.22.

---
updated-dependencies:
- dependency-name: alpine dependency-version: '3.22' dependency-type: direct:production update-type: version-update:semver-minor ...