### PR TITLE
Add Nomorobo, Should I Answer, Veriphone, FTC DNC scanners + spoof-risk signal + new web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ coverage
 coverage.*
 unit-tests.xml
 .idea
+
+# API keys for local testing (NUMVERIFY_API_KEY etc.) - never commit these
+.env

--- a/lib/output/console.go
+++ b/lib/output/console.go
@@ -98,12 +98,22 @@ func (o *ConsoleOutput) displayResult(val interface{}, prefix string) {
 	}
 }
 
+// google-prefixed scanners (googlesearch, googlecse) just emit long lists of
+// search-dork links - sort them after everything else so the more concise,
+// higher-signal results (numverify, nomorobo, shouldianswer, local...) show first.
 func getSortedResultKeys(m map[string]interface{}) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		iGoogle := strings.HasPrefix(keys[i], "google")
+		jGoogle := strings.HasPrefix(keys[j], "google")
+		if iGoogle != jGoogle {
+			return jGoogle
+		}
+		return keys[i] < keys[j]
+	})
 	return keys
 }
 

--- a/lib/remote/ftc_scanner.go
+++ b/lib/remote/ftc_scanner.go
@@ -1,0 +1,75 @@
+package remote
+
+import (
+	"errors"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+)
+
+const FTC = "ftc"
+
+// ftcDaysToCheck bounds how many calendar days back to scan - each day is a
+// ~1MB CSV fetched in full (no server-side phone filter exists), so this is a
+// deliberate cost/recency tradeoff, not an arbitrary number.
+const ftcDaysToCheck = 7
+
+type ftcScanner struct {
+	client suppliers.FTCSupplierInterface
+}
+
+type FTCComplaintEntry struct {
+	Date     string `json:"date" console:"Date,omitempty"`
+	State    string `json:"state" console:"State,omitempty"`
+	Subject  string `json:"subject" console:"Subject,omitempty"`
+	Robocall string `json:"robocall" console:"Robocall,omitempty"`
+}
+
+type FTCComplaintScannerResponse struct {
+	DaysChecked      int                 `json:"days_checked" console:"Days checked"`
+	ComplaintCount   int                 `json:"complaint_count" console:"Complaints reported"`
+	RecentComplaints []FTCComplaintEntry `json:"recent_complaints,omitempty" console:"Recent complaints,omitempty"`
+}
+
+func NewFTCScanner(s suppliers.FTCSupplierInterface) Scanner {
+	return &ftcScanner{client: s}
+}
+
+func (s *ftcScanner) Name() string {
+	return FTC
+}
+
+func (s *ftcScanner) Description() string {
+	return "Check the FTC's public Do Not Call complaint data (last published week) for reports against this number."
+}
+
+func (s *ftcScanner) DryRun(n number.Number, _ ScannerOptions) error {
+	if n.CountryCode != 1 || len(n.RawLocal) != 10 {
+		return errors.New("only US/Canada numbers are supported")
+	}
+	return nil
+}
+
+func (s *ftcScanner) Run(n number.Number, _ ScannerOptions) (interface{}, error) {
+	res, err := s.client.CountComplaints(n.RawLocal, ftcDaysToCheck)
+	if err != nil {
+		return nil, err
+	}
+
+	// leave nil (not an empty slice) when there are no complaints, so the
+	// "omitempty" console tag actually suppresses the field
+	var entries []FTCComplaintEntry
+	for _, c := range res.Complaints {
+		entries = append(entries, FTCComplaintEntry{
+			Date:     c.Date,
+			State:    c.State,
+			Subject:  c.Subject,
+			Robocall: c.Robocall,
+		})
+	}
+
+	return FTCComplaintScannerResponse{
+		DaysChecked:      res.DaysChecked,
+		ComplaintCount:   len(entries),
+		RecentComplaints: entries,
+	}, nil
+}

--- a/lib/remote/ftc_scanner_test.go
+++ b/lib/remote/ftc_scanner_test.go
@@ -1,0 +1,107 @@
+package remote_test
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/lib/filter"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+	"testing"
+)
+
+type ftcSupplierMock struct {
+	response *suppliers.FTCComplaintsResponse
+	err      error
+}
+
+func (m *ftcSupplierMock) CountComplaints(_ string, _ int) (*suppliers.FTCComplaintsResponse, error) {
+	return m.response, m.err
+}
+
+func TestFTCScanner_Metadata(t *testing.T) {
+	scanner := remote.NewFTCScanner(&ftcSupplierMock{})
+	assert.Equal(t, remote.FTC, scanner.Name())
+	assert.NotEmpty(t, scanner.Description())
+}
+
+func TestFTCScanner(t *testing.T) {
+	dummyError := errors.New("dummy")
+	usNumber, _ := number.NewNumber("17027515054")
+	frNumber, _ := number.NewNumber("33365174444")
+
+	testcases := []struct {
+		name       string
+		number     *number.Number
+		supplier   *ftcSupplierMock
+		expected   map[string]interface{}
+		wantErrors map[string]error
+	}{
+		{
+			name:   "no complaints found",
+			number: usNumber,
+			supplier: &ftcSupplierMock{
+				response: &suppliers.FTCComplaintsResponse{DaysChecked: 5},
+			},
+			expected: map[string]interface{}{
+				"ftc": remote.FTCComplaintScannerResponse{
+					DaysChecked:    5,
+					ComplaintCount: 0,
+				},
+			},
+			wantErrors: map[string]error{},
+		},
+		{
+			name:   "complaints found",
+			number: usNumber,
+			supplier: &ftcSupplierMock{
+				response: &suppliers.FTCComplaintsResponse{
+					DaysChecked: 5,
+					Complaints: []suppliers.FTCComplaint{
+						{Date: "2026-07-29", State: "Nevada", Subject: "Other", Robocall: "Y"},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"ftc": remote.FTCComplaintScannerResponse{
+					DaysChecked:    5,
+					ComplaintCount: 1,
+					RecentComplaints: []remote.FTCComplaintEntry{
+						{Date: "2026-07-29", State: "Nevada", Subject: "Other", Robocall: "Y"},
+					},
+				},
+			},
+			wantErrors: map[string]error{},
+		},
+		{
+			name:       "failed scan",
+			number:     usNumber,
+			supplier:   &ftcSupplierMock{err: dummyError},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{"ftc": dummyError},
+		},
+		{
+			name:       "country not supported",
+			number:     frNumber,
+			supplier:   &ftcSupplierMock{},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := remote.NewFTCScanner(tt.supplier)
+			lib := remote.NewLibrary(filter.NewEngine())
+			lib.AddScanner(scanner)
+
+			got, errs := lib.Scan(tt.number, remote.ScannerOptions{})
+			if len(tt.wantErrors) > 0 {
+				assert.Equal(t, tt.wantErrors, errs)
+			} else {
+				assert.Len(t, errs, 0)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/lib/remote/init.go
+++ b/lib/remote/init.go
@@ -7,12 +7,16 @@ import (
 func InitScanners(remote *Library) {
 	numverifySupplier := suppliers.NewNumverifySupplier()
 	ovhSupplier := suppliers.NewOVHSupplier()
+	nomoroboSupplier := suppliers.NewNomoroboSupplier()
+	shouldianswerSupplier := suppliers.NewShouldIAnswerSupplier()
 
 	remote.AddScanner(NewLocalScanner())
 	remote.AddScanner(NewNumverifyScanner(numverifySupplier))
 	remote.AddScanner(NewGoogleSearchScanner())
 	remote.AddScanner(NewOVHScanner(ovhSupplier))
 	remote.AddScanner(NewGoogleCSEScanner(nil))
+	remote.AddScanner(NewNomoroboScanner(nomoroboSupplier))
+	remote.AddScanner(NewShouldIAnswerScanner(shouldianswerSupplier))
 
 	remote.LoadPlugins()
 }

--- a/lib/remote/init.go
+++ b/lib/remote/init.go
@@ -10,6 +10,7 @@ func InitScanners(remote *Library) {
 	nomoroboSupplier := suppliers.NewNomoroboSupplier()
 	shouldianswerSupplier := suppliers.NewShouldIAnswerSupplier()
 	veriphoneSupplier := suppliers.NewVeriphoneSupplier()
+	ftcSupplier := suppliers.NewFTCSupplier()
 
 	remote.AddScanner(NewLocalScanner())
 	remote.AddScanner(NewNumverifyScanner(numverifySupplier))
@@ -19,6 +20,7 @@ func InitScanners(remote *Library) {
 	remote.AddScanner(NewNomoroboScanner(nomoroboSupplier))
 	remote.AddScanner(NewShouldIAnswerScanner(shouldianswerSupplier))
 	remote.AddScanner(NewVeriphoneScanner(veriphoneSupplier))
+	remote.AddScanner(NewFTCScanner(ftcSupplier))
 
 	remote.LoadPlugins()
 }

--- a/lib/remote/init.go
+++ b/lib/remote/init.go
@@ -9,6 +9,7 @@ func InitScanners(remote *Library) {
 	ovhSupplier := suppliers.NewOVHSupplier()
 	nomoroboSupplier := suppliers.NewNomoroboSupplier()
 	shouldianswerSupplier := suppliers.NewShouldIAnswerSupplier()
+	veriphoneSupplier := suppliers.NewVeriphoneSupplier()
 
 	remote.AddScanner(NewLocalScanner())
 	remote.AddScanner(NewNumverifyScanner(numverifySupplier))
@@ -17,6 +18,7 @@ func InitScanners(remote *Library) {
 	remote.AddScanner(NewGoogleCSEScanner(nil))
 	remote.AddScanner(NewNomoroboScanner(nomoroboSupplier))
 	remote.AddScanner(NewShouldIAnswerScanner(shouldianswerSupplier))
+	remote.AddScanner(NewVeriphoneScanner(veriphoneSupplier))
 
 	remote.LoadPlugins()
 }

--- a/lib/remote/nomorobo_scanner.go
+++ b/lib/remote/nomorobo_scanner.go
@@ -1,0 +1,45 @@
+package remote
+
+import (
+	"errors"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+)
+
+const Nomorobo = "nomorobo"
+
+type nomoroboScanner struct {
+	client suppliers.NomoroboSupplierInterface
+}
+
+type NomoroboScannerResponse struct {
+	Description string `json:"description" console:"Description,omitempty"`
+}
+
+func NewNomoroboScanner(s suppliers.NomoroboSupplierInterface) Scanner {
+	return &nomoroboScanner{client: s}
+}
+
+func (s *nomoroboScanner) Name() string {
+	return Nomorobo
+}
+
+func (s *nomoroboScanner) Description() string {
+	return "Look up a US/Canada number's caller classification on Nomorobo (free, no API key)."
+}
+
+func (s *nomoroboScanner) DryRun(n number.Number, _ ScannerOptions) error {
+	if n.CountryCode != 1 || len(n.RawLocal) != 10 {
+		return errors.New("only US/Canada numbers are supported")
+	}
+	return nil
+}
+
+func (s *nomoroboScanner) Run(n number.Number, _ ScannerOptions) (interface{}, error) {
+	res, err := s.client.Lookup(n.RawLocal)
+	if err != nil {
+		return nil, err
+	}
+
+	return NomoroboScannerResponse{Description: res.Description}, nil
+}

--- a/lib/remote/nomorobo_scanner_test.go
+++ b/lib/remote/nomorobo_scanner_test.go
@@ -1,0 +1,86 @@
+package remote_test
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/lib/filter"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+	"testing"
+)
+
+type nomoroboSupplierMock struct {
+	response *suppliers.NomoroboScannerResponse
+	err      error
+}
+
+func (m *nomoroboSupplierMock) Lookup(_ string) (*suppliers.NomoroboScannerResponse, error) {
+	return m.response, m.err
+}
+
+func TestNomoroboScanner_Metadata(t *testing.T) {
+	scanner := remote.NewNomoroboScanner(&nomoroboSupplierMock{})
+	assert.Equal(t, remote.Nomorobo, scanner.Name())
+	assert.NotEmpty(t, scanner.Description())
+}
+
+func TestNomoroboScanner(t *testing.T) {
+	dummyError := errors.New("dummy")
+	usNumber, _ := number.NewNumber("17027515054")
+	frNumber, _ := number.NewNumber("33365174444")
+
+	testcases := []struct {
+		name       string
+		number     *number.Number
+		supplier   *nomoroboSupplierMock
+		expected   map[string]interface{}
+		wantErrors map[string]error
+	}{
+		{
+			name:   "successful scan",
+			number: usNumber,
+			supplier: &nomoroboSupplierMock{
+				response: &suppliers.NomoroboScannerResponse{Description: "Unknown Caller"},
+			},
+			expected: map[string]interface{}{
+				"nomorobo": remote.NomoroboScannerResponse{Description: "Unknown Caller"},
+			},
+			wantErrors: map[string]error{},
+		},
+		{
+			name:   "failed scan",
+			number: usNumber,
+			supplier: &nomoroboSupplierMock{
+				err: dummyError,
+			},
+			expected: map[string]interface{}{},
+			wantErrors: map[string]error{
+				"nomorobo": dummyError,
+			},
+		},
+		{
+			name:       "country not supported",
+			number:     frNumber,
+			supplier:   &nomoroboSupplierMock{},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := remote.NewNomoroboScanner(tt.supplier)
+			lib := remote.NewLibrary(filter.NewEngine())
+			lib.AddScanner(scanner)
+
+			got, errs := lib.Scan(tt.number, remote.ScannerOptions{})
+			if len(tt.wantErrors) > 0 {
+				assert.Equal(t, tt.wantErrors, errs)
+			} else {
+				assert.Len(t, errs, 0)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/lib/remote/numverify_scanner.go
+++ b/lib/remote/numverify_scanner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/sundowndev/phoneinfoga/v2/lib/number"
 	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+	"strings"
 )
 
 const Numverify = "numverify"
@@ -23,6 +24,50 @@ type NumverifyScannerResponse struct {
 	Location            string `json:"location" console:"Location,omitempty"`
 	Carrier             string `json:"carrier" console:"Carrier,omitempty"`
 	LineType            string `json:"line_type" console:"Line type,omitempty"`
+	SpoofRisk           string `json:"spoof_risk" console:"Spoof risk,omitempty"`
+}
+
+// knownVoipCarriers is a non-exhaustive list of wholesale/CLEC carriers commonly
+// underlying VOIP and app-based numbers (Google Voice, Skype, TextNow, RingCentral,
+// etc. are all provisioned through carriers like these rather than showing up by name).
+var knownVoipCarriers = []string{
+	"bandwidth", "level 3", "level3", "lumen", "twilio", "onvoy", "inteliquent",
+	"neutral tandem", "peerless", "flowroute", "telnyx", "sinch", "vonage",
+	"ringcentral", "8x8", "zipwhip", "voip innovations", "voxbone", "skype",
+	"broadvoice", "callcentric", "vitelity",
+}
+
+// assessSpoofRisk gives a rough, honest signal for "is the caller ID here likely
+// spoofable" based on carrier/line-type data alone. It can NOT determine whether a
+// call actually was spoofed, or where a call really originated - no phone-number
+// lookup can do that without carrier-level call records. This is a proxy, not a verdict.
+func assessSpoofRisk(carrier, lineType string) string {
+	lowerCarrier := strings.ToLower(carrier)
+	lowerLineType := strings.ToLower(lineType)
+
+	if lowerLineType == "voip" {
+		return "elevated - line type reported as VOIP"
+	}
+
+	for _, known := range knownVoipCarriers {
+		if strings.Contains(lowerCarrier, known) {
+			return "elevated - carrier is a VOIP/wholesale provider (" + carrier + ")"
+		}
+	}
+
+	if lowerLineType == "landline" && carrier == "" {
+		return "uncertain - \"landline\" with no carrier attribution; free-tier databases often mislabel ported/VOIP numbers this way"
+	}
+
+	if lowerLineType == "mobile" && carrier != "" {
+		return "low - mobile line with a named carrier"
+	}
+
+	if lowerLineType == "landline" && carrier != "" {
+		return "low - landline with a named carrier"
+	}
+
+	return "unknown - not enough data"
 }
 
 func NewNumverifyScanner(s suppliers.NumverifySupplierInterface) Scanner {
@@ -63,6 +108,7 @@ func (s *numverifyScanner) Run(n number.Number, opts ScannerOptions) (interface{
 		Location:            res.Location,
 		Carrier:             res.Carrier,
 		LineType:            res.LineType,
+		SpoofRisk:           assessSpoofRisk(res.Carrier, res.LineType),
 	}
 
 	return data, nil

--- a/lib/remote/numverify_scanner_test.go
+++ b/lib/remote/numverify_scanner_test.go
@@ -65,6 +65,7 @@ func TestNumverifyScanner(t *testing.T) {
 					Location:            "test",
 					Carrier:             "test",
 					LineType:            "test",
+					SpoofRisk:           "unknown - not enough data",
 				},
 			},
 			wantErrors: map[string]error{},

--- a/lib/remote/shouldianswer_scanner.go
+++ b/lib/remote/shouldianswer_scanner.go
@@ -1,0 +1,46 @@
+package remote
+
+import (
+	"errors"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+)
+
+const ShouldIAnswer = "shouldianswer"
+
+type shouldianswerScanner struct {
+	client suppliers.ShouldIAnswerSupplierInterface
+}
+
+type ShouldIAnswerScannerResponse struct {
+	Score   string `json:"score" console:"Score"`
+	Summary string `json:"summary,omitempty" console:"Summary,omitempty"`
+}
+
+func NewShouldIAnswerScanner(s suppliers.ShouldIAnswerSupplierInterface) Scanner {
+	return &shouldianswerScanner{client: s}
+}
+
+func (s *shouldianswerScanner) Name() string {
+	return ShouldIAnswer
+}
+
+func (s *shouldianswerScanner) Description() string {
+	return "Look up a US/Canada number's community rating on shouldianswer.com (free, no API key)."
+}
+
+func (s *shouldianswerScanner) DryRun(n number.Number, _ ScannerOptions) error {
+	if n.CountryCode != 1 || len(n.RawLocal) != 10 {
+		return errors.New("only US/Canada numbers are supported")
+	}
+	return nil
+}
+
+func (s *shouldianswerScanner) Run(n number.Number, _ ScannerOptions) (interface{}, error) {
+	res, err := s.client.Lookup(n.RawLocal)
+	if err != nil {
+		return nil, err
+	}
+
+	return ShouldIAnswerScannerResponse{Score: res.Score, Summary: res.Summary}, nil
+}

--- a/lib/remote/shouldianswer_scanner_test.go
+++ b/lib/remote/shouldianswer_scanner_test.go
@@ -1,0 +1,86 @@
+package remote_test
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/lib/filter"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+	"testing"
+)
+
+type shouldianswerSupplierMock struct {
+	response *suppliers.ShouldIAnswerScannerResponse
+	err      error
+}
+
+func (m *shouldianswerSupplierMock) Lookup(_ string) (*suppliers.ShouldIAnswerScannerResponse, error) {
+	return m.response, m.err
+}
+
+func TestShouldIAnswerScanner_Metadata(t *testing.T) {
+	scanner := remote.NewShouldIAnswerScanner(&shouldianswerSupplierMock{})
+	assert.Equal(t, remote.ShouldIAnswer, scanner.Name())
+	assert.NotEmpty(t, scanner.Description())
+}
+
+func TestShouldIAnswerScanner(t *testing.T) {
+	dummyError := errors.New("dummy")
+	usNumber, _ := number.NewNumber("17027515054")
+	frNumber, _ := number.NewNumber("33365174444")
+
+	testcases := []struct {
+		name       string
+		number     *number.Number
+		supplier   *shouldianswerSupplierMock
+		expected   map[string]interface{}
+		wantErrors map[string]error
+	}{
+		{
+			name:   "successful scan",
+			number: usNumber,
+			supplier: &shouldianswerSupplierMock{
+				response: &suppliers.ShouldIAnswerScannerResponse{Score: "unknown", Summary: "no reports"},
+			},
+			expected: map[string]interface{}{
+				"shouldianswer": remote.ShouldIAnswerScannerResponse{Score: "unknown", Summary: "no reports"},
+			},
+			wantErrors: map[string]error{},
+		},
+		{
+			name:   "failed scan",
+			number: usNumber,
+			supplier: &shouldianswerSupplierMock{
+				err: dummyError,
+			},
+			expected: map[string]interface{}{},
+			wantErrors: map[string]error{
+				"shouldianswer": dummyError,
+			},
+		},
+		{
+			name:       "country not supported",
+			number:     frNumber,
+			supplier:   &shouldianswerSupplierMock{},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := remote.NewShouldIAnswerScanner(tt.supplier)
+			lib := remote.NewLibrary(filter.NewEngine())
+			lib.AddScanner(scanner)
+
+			got, errs := lib.Scan(tt.number, remote.ScannerOptions{})
+			if len(tt.wantErrors) > 0 {
+				assert.Equal(t, tt.wantErrors, errs)
+			} else {
+				assert.Len(t, errs, 0)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/lib/remote/suppliers/ftc.go
+++ b/lib/remote/suppliers/ftc.go
@@ -1,0 +1,119 @@
+package suppliers
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type FTCSupplierInterface interface {
+	CountComplaints(rawLocal string, days int) (*FTCComplaintsResponse, error)
+}
+
+type FTCComplaint struct {
+	Date     string
+	State    string
+	Subject  string
+	Robocall string
+}
+
+type FTCComplaintsResponse struct {
+	DaysChecked int
+	Complaints  []FTCComplaint
+}
+
+type FTCSupplier struct {
+	BaseUri string
+}
+
+func NewFTCSupplier() *FTCSupplier {
+	return &FTCSupplier{BaseUri: "https://www.ftc.gov/sites/default/files"}
+}
+
+// CountComplaints scrapes the FTC's daily Do Not Call complaint CSVs, published at
+// a predictable URL per weekday (no auth, no API key - the documented api.ftc.gov
+// endpoint returns static sandbox data regardless of parameters, so this is the
+// only way to actually filter by phone number). There's no per-number server-side
+// filter, so each day's file (roughly 1MB, a few thousand rows) is matched client-side.
+func (s *FTCSupplier) CountComplaints(rawLocal string, days int) (*FTCComplaintsResponse, error) {
+	res := &FTCComplaintsResponse{}
+
+	for i := 0; i < days; i++ {
+		date := time.Now().AddDate(0, 0, -i)
+		url := fmt.Sprintf("%s/DNC_Complaint_Numbers_%s.csv", s.BaseUri, date.Format("2006-01-02"))
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		// No file is published on weekends/holidays - just skip those days.
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			continue
+		}
+		res.DaysChecked++
+
+		rows, err := csv.NewReader(resp.Body).ReadAll()
+		resp.Body.Close()
+		if err != nil || len(rows) < 2 {
+			continue
+		}
+
+		col := columnIndexer(rows[0])
+		phoneIdx := col("Company_Phone_Number")
+		if phoneIdx == -1 {
+			continue
+		}
+		dateIdx, stateIdx, subjectIdx, robocallIdx := col("Created_Date"), col("Consumer_State"), col("Subject"), col("Recorded_Message_Or_Robocall")
+
+		for _, row := range rows[1:] {
+			if phoneIdx >= len(row) || !matchesLocalNumber(row[phoneIdx], rawLocal) {
+				continue
+			}
+			res.Complaints = append(res.Complaints, FTCComplaint{
+				Date:     safeCol(row, dateIdx),
+				State:    safeCol(row, stateIdx),
+				Subject:  safeCol(row, subjectIdx),
+				Robocall: safeCol(row, robocallIdx),
+			})
+		}
+	}
+
+	return res, nil
+}
+
+func columnIndexer(header []string) func(name string) int {
+	return func(name string) int {
+		for i, h := range header {
+			if h == name {
+				return i
+			}
+		}
+		return -1
+	}
+}
+
+func safeCol(row []string, idx int) string {
+	if idx == -1 || idx >= len(row) {
+		return ""
+	}
+	return row[idx]
+}
+
+// matchesLocalNumber compares a CSV phone value against a 10-digit US/Canada
+// local number, stripping a leading NANP country code "1" if present (an area
+// code can never start with 0 or 1, so this can't misfire on a real local number).
+func matchesLocalNumber(csvPhone, rawLocal string) bool {
+	if len(csvPhone) == 11 && csvPhone[0] == '1' {
+		csvPhone = csvPhone[1:]
+	}
+	return csvPhone == rawLocal
+}

--- a/lib/remote/suppliers/nomorobo.go
+++ b/lib/remote/suppliers/nomorobo.go
@@ -1,0 +1,60 @@
+package suppliers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+)
+
+type NomoroboSupplierInterface interface {
+	Lookup(rawLocal string) (*NomoroboScannerResponse, error)
+}
+
+// NomoroboScannerResponse is the Nomorobo scanner response
+type NomoroboScannerResponse struct {
+	Description string
+}
+
+type NomoroboSupplier struct {
+	Uri string
+}
+
+func NewNomoroboSupplier() *NomoroboSupplier {
+	return &NomoroboSupplier{Uri: "https://www.nomorobo.com"}
+}
+
+// Nomorobo puts the actual verdict in the page's meta description, e.g.
+// "(702) 751-5054 is an Unknown Caller. We have no other information about this number."
+var nomoroboDescriptionRegexp = regexp.MustCompile(`name="description" content="([^"]+)"`)
+
+func (s *NomoroboSupplier) Lookup(rawLocal string) (*NomoroboScannerResponse, error) {
+	if len(rawLocal) != 10 {
+		return nil, fmt.Errorf("expected a 10-digit US/Canada number, got %q", rawLocal)
+	}
+	dashed := fmt.Sprintf("%s-%s-%s", rawLocal[0:3], rawLocal[3:6], rawLocal[6:10])
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/lookup/%s", s.Uri, dashed), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	match := nomoroboDescriptionRegexp.FindSubmatch(body)
+	if match == nil {
+		return &NomoroboScannerResponse{}, nil
+	}
+
+	return &NomoroboScannerResponse{Description: string(match[1])}, nil
+}

--- a/lib/remote/suppliers/numverify.go
+++ b/lib/remote/suppliers/numverify.go
@@ -64,48 +64,74 @@ func (r *NumverifyRequest) ValidateNumber(internationalNumber string) (res *Numv
 		WithField("number", internationalNumber).
 		Debug("Running validate operation through Numverify API")
 
+	res, statusCode, err := r.validateViaMarketplace(internationalNumber)
+	if err != nil {
+		return nil, err
+	}
+	if res != nil {
+		return res, nil
+	}
+
+	// A 401 here means the key isn't an apilayer.com marketplace key - most free
+	// keys from numverify.com's own signup are the older style, which only this
+	// legacy endpoint accepts (and only over plain HTTP - HTTPS is a paid feature
+	// on that plan). Only fall back on 401 so real marketplace-key errors
+	// (rate limit, bad number, etc.) still surface normally.
+	if statusCode == http.StatusUnauthorized {
+		logrus.Debug("Numverify marketplace auth failed, retrying against legacy numverify.com endpoint")
+		return r.validateViaLegacyEndpoint(internationalNumber)
+	}
+
+	return nil, errors.New("numverify request failed")
+}
+
+func (r *NumverifyRequest) validateViaMarketplace(internationalNumber string) (res *NumverifyValidateResponse, statusCode int, err error) {
 	url := fmt.Sprintf("%s/number_verification/validate?number=%s", r.uri, internationalNumber)
 
-	// Build the request
 	client := &http.Client{}
 	req, _ := http.NewRequest("GET", url, nil)
 	req.Header.Set("Apikey", r.apiKey)
 
 	response, err := client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer response.Body.Close()
 
+	if response.StatusCode >= 400 {
+		if response.StatusCode == http.StatusUnauthorized {
+			return nil, response.StatusCode, nil
+		}
+		errorResponse := NumverifyErrorResponse{}
+		if err := json.NewDecoder(response.Body).Decode(&errorResponse); err != nil {
+			return nil, response.StatusCode, err
+		}
+		return nil, response.StatusCode, errors.New(errorResponse.Message)
+	}
+
+	var result NumverifyValidateResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return nil, response.StatusCode, err
+	}
+
+	return &result, response.StatusCode, nil
+}
+
+// validateViaLegacyEndpoint talks to the original numverify.com free-tier API:
+// plain HTTP only, auth via access_key query param instead of a header.
+func (r *NumverifyRequest) validateViaLegacyEndpoint(internationalNumber string) (res *NumverifyValidateResponse, err error) {
+	url := fmt.Sprintf("http://apilayer.net/api/validate?access_key=%s&number=%s", r.apiKey, internationalNumber)
+
+	response, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Body.Close()
 
-	// Fill the response with the data from the JSON
 	var result NumverifyValidateResponse
-
-	if response.StatusCode >= 400 {
-		errorResponse := NumverifyErrorResponse{}
-		if err := json.NewDecoder(response.Body).Decode(&errorResponse); err != nil {
-			return nil, err
-		}
-		return nil, errors.New(errorResponse.Message)
-	}
-
-	// Use json.Decode for reading streams of JSON data
 	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
 		return nil, err
 	}
 
-	res = &NumverifyValidateResponse{
-		Valid:               result.Valid,
-		Number:              result.Number,
-		LocalFormat:         result.LocalFormat,
-		InternationalFormat: result.InternationalFormat,
-		CountryPrefix:       result.CountryPrefix,
-		CountryCode:         result.CountryCode,
-		CountryName:         result.CountryName,
-		Location:            result.Location,
-		Carrier:             result.Carrier,
-		LineType:            result.LineType,
-	}
-
-	return res, nil
+	return &result, nil
 }

--- a/lib/remote/suppliers/numverify_test.go
+++ b/lib/remote/suppliers/numverify_test.go
@@ -67,6 +67,46 @@ func TestNumverifySupplierError(t *testing.T) {
 	assert.Equal(t, errors.New("You have exceeded your daily\\/monthly API rate limit. Please review and upgrade your subscription plan at https:\\/\\/apilayer.com\\/subscriptions to continue."), err)
 }
 
+func TestNumverifySupplierFallsBackToLegacyEndpointOn401(t *testing.T) {
+	defer gock.Off() // Flush pending mocks after test execution
+
+	number := "17027515054"
+	apikey := "legacy-style-free-key"
+
+	gock.New("https://api.apilayer.com").
+		Get("/number_verification/validate").
+		MatchParam("number", number).
+		Reply(401).
+		JSON(map[string]string{"message": "Invalid authentication credentials"})
+
+	expectedResult := &NumverifyValidateResponse{
+		Valid:               true,
+		Number:              "17027515054",
+		LocalFormat:         "7027515054",
+		InternationalFormat: "+17027515054",
+		CountryPrefix:       "+1",
+		CountryCode:         "US",
+		CountryName:         "United States of America",
+		Location:            "Indian Spg",
+		Carrier:             "",
+		LineType:            "landline",
+	}
+
+	gock.New("http://apilayer.net").
+		Get("/api/validate").
+		MatchParam("access_key", apikey).
+		MatchParam("number", number).
+		Reply(200).
+		JSON(expectedResult)
+
+	s := NewNumverifySupplier()
+
+	got, err := s.Request().SetApiKey(apikey).ValidateNumber(number)
+	assert.Nil(t, err)
+
+	assert.Equal(t, expectedResult, got)
+}
+
 func TestNumverifySupplierHTTPError(t *testing.T) {
 	defer gock.Off() // Flush pending mocks after test execution
 

--- a/lib/remote/suppliers/shouldianswer.go
+++ b/lib/remote/suppliers/shouldianswer.go
@@ -1,0 +1,67 @@
+package suppliers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type ShouldIAnswerSupplierInterface interface {
+	Lookup(rawLocal string) (*ShouldIAnswerScannerResponse, error)
+}
+
+// ShouldIAnswerScannerResponse is the Should I Answer scanner response
+type ShouldIAnswerScannerResponse struct {
+	Score   string // "unknown", "positive" or "negative"
+	Summary string
+}
+
+type ShouldIAnswerSupplier struct {
+	Uri string
+}
+
+func NewShouldIAnswerSupplier() *ShouldIAnswerSupplier {
+	return &ShouldIAnswerSupplier{Uri: "https://www.shouldianswer.com"}
+}
+
+// The page carries the community verdict as a CSS class (score unknown/positive/negative)
+// and a plain-text summary paragraph - no login wall, no API needed.
+var shouldianswerScoreRegexp = regexp.MustCompile(`class="score (\w+)"`)
+var shouldianswerInfoxRegexp = regexp.MustCompile(`(?s)class="infox">\s*(.+?)\s*</div>`)
+var htmlTagRegexp = regexp.MustCompile(`<[^>]+>`)
+
+func (s *ShouldIAnswerSupplier) Lookup(rawLocal string) (*ShouldIAnswerScannerResponse, error) {
+	if len(rawLocal) != 10 {
+		return nil, fmt.Errorf("expected a 10-digit US/Canada number, got %q", rawLocal)
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/phone-number/%s", s.Uri, rawLocal), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ShouldIAnswerScannerResponse{Score: "unknown"}
+
+	if m := shouldianswerScoreRegexp.FindSubmatch(body); m != nil {
+		res.Score = string(m[1])
+	}
+	if m := shouldianswerInfoxRegexp.FindSubmatch(body); m != nil {
+		res.Summary = strings.TrimSpace(htmlTagRegexp.ReplaceAllString(string(m[1]), ""))
+	}
+
+	return res, nil
+}

--- a/lib/remote/suppliers/veriphone.go
+++ b/lib/remote/suppliers/veriphone.go
@@ -1,0 +1,68 @@
+package suppliers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type VeriphoneSupplierInterface interface {
+	Verify(apiKey string, internationalNumber string) (*VeriphoneResponse, error)
+}
+
+// VeriphoneResponse mirrors https://api.veriphone.io/v3/verify's JSON shape
+type VeriphoneResponse struct {
+	Status              string `json:"status"`
+	Phone               string `json:"phone"`
+	PhoneValid          bool   `json:"phone_valid"`
+	PhoneType           string `json:"phone_type"`
+	PhoneRegion         string `json:"phone_region"`
+	Country             string `json:"country"`
+	CountryCode         string `json:"country_code"`
+	CountryPrefix       string `json:"country_prefix"`
+	InternationalNumber string `json:"international_number"`
+	LocalNumber         string `json:"local_number"`
+	E164                string `json:"e164"`
+	Carrier             string `json:"carrier"`
+	Error               string `json:"error"`
+}
+
+type VeriphoneSupplier struct {
+	Uri string
+}
+
+func NewVeriphoneSupplier() *VeriphoneSupplier {
+	return &VeriphoneSupplier{Uri: "https://api.veriphone.io/v3"}
+}
+
+func (s *VeriphoneSupplier) Verify(apiKey string, internationalNumber string) (*VeriphoneResponse, error) {
+	reqUrl := fmt.Sprintf("%s/verify?phone=%s", s.Uri, url.QueryEscape("+"+internationalNumber))
+
+	req, err := http.NewRequest("GET", reqUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result VeriphoneResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	if result.Status != "success" {
+		if result.Error != "" {
+			return nil, errors.New(result.Error)
+		}
+		return nil, errors.New("veriphone request failed")
+	}
+
+	return &result, nil
+}

--- a/lib/remote/veriphone_scanner.go
+++ b/lib/remote/veriphone_scanner.go
@@ -1,0 +1,63 @@
+package remote
+
+import (
+	"errors"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+)
+
+const Veriphone = "veriphone"
+
+type veriphoneScanner struct {
+	client suppliers.VeriphoneSupplierInterface
+}
+
+type VeriphoneScannerResponse struct {
+	PhoneValid          bool   `json:"phone_valid" console:"Valid"`
+	PhoneType           string `json:"phone_type" console:"Phone type,omitempty"`
+	PhoneRegion         string `json:"phone_region" console:"Phone region,omitempty"`
+	Country             string `json:"country" console:"Country,omitempty"`
+	CountryCode         string `json:"country_code" console:"Country code,omitempty"`
+	InternationalNumber string `json:"international_number" console:"International number,omitempty"`
+	Carrier             string `json:"carrier" console:"Carrier,omitempty"`
+	SpoofRisk           string `json:"spoof_risk" console:"Spoof risk,omitempty"`
+}
+
+func NewVeriphoneScanner(s suppliers.VeriphoneSupplierInterface) Scanner {
+	return &veriphoneScanner{client: s}
+}
+
+func (s *veriphoneScanner) Name() string {
+	return Veriphone
+}
+
+func (s *veriphoneScanner) Description() string {
+	return "Cross-check carrier/line-type via Veriphone, a second independent source from Numverify (free, needs VERIPHONE_API_KEY)."
+}
+
+func (s *veriphoneScanner) DryRun(_ number.Number, opts ScannerOptions) error {
+	if opts.GetStringEnv("VERIPHONE_API_KEY") != "" {
+		return nil
+	}
+	return errors.New("API key is not defined")
+}
+
+func (s *veriphoneScanner) Run(n number.Number, opts ScannerOptions) (interface{}, error) {
+	apiKey := opts.GetStringEnv("VERIPHONE_API_KEY")
+
+	res, err := s.client.Verify(apiKey, n.International)
+	if err != nil {
+		return nil, err
+	}
+
+	return VeriphoneScannerResponse{
+		PhoneValid:          res.PhoneValid,
+		PhoneType:           res.PhoneType,
+		PhoneRegion:         res.PhoneRegion,
+		Country:             res.Country,
+		CountryCode:         res.CountryCode,
+		InternationalNumber: res.InternationalNumber,
+		Carrier:             res.Carrier,
+		SpoofRisk:           assessSpoofRisk(res.Carrier, res.PhoneType),
+	}, nil
+}

--- a/lib/remote/veriphone_scanner_test.go
+++ b/lib/remote/veriphone_scanner_test.go
@@ -1,0 +1,98 @@
+package remote_test
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/sundowndev/phoneinfoga/v2/lib/filter"
+	"github.com/sundowndev/phoneinfoga/v2/lib/number"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote"
+	"github.com/sundowndev/phoneinfoga/v2/lib/remote/suppliers"
+	"testing"
+)
+
+type veriphoneSupplierMock struct {
+	response *suppliers.VeriphoneResponse
+	err      error
+}
+
+func (m *veriphoneSupplierMock) Verify(_ string, _ string) (*suppliers.VeriphoneResponse, error) {
+	return m.response, m.err
+}
+
+func TestVeriphoneScanner_Metadata(t *testing.T) {
+	scanner := remote.NewVeriphoneScanner(&veriphoneSupplierMock{})
+	assert.Equal(t, remote.Veriphone, scanner.Name())
+	assert.NotEmpty(t, scanner.Description())
+}
+
+func TestVeriphoneScanner(t *testing.T) {
+	dummyError := errors.New("dummy")
+	dummyNumber, _ := number.NewNumber("17027515054")
+
+	testcases := []struct {
+		name       string
+		opts       remote.ScannerOptions
+		supplier   *veriphoneSupplierMock
+		expected   map[string]interface{}
+		wantErrors map[string]error
+	}{
+		{
+			name: "successful scan",
+			opts: remote.ScannerOptions{"VERIPHONE_API_KEY": "secret"},
+			supplier: &veriphoneSupplierMock{
+				response: &suppliers.VeriphoneResponse{
+					PhoneValid:  true,
+					PhoneType:   "voip",
+					Country:     "United States",
+					CountryCode: "US",
+					Carrier:     "Bandwidth.com",
+				},
+			},
+			expected: map[string]interface{}{
+				"veriphone": remote.VeriphoneScannerResponse{
+					PhoneValid:  true,
+					PhoneType:   "voip",
+					Country:     "United States",
+					CountryCode: "US",
+					Carrier:     "Bandwidth.com",
+					SpoofRisk:   "elevated - line type reported as VOIP",
+				},
+			},
+			wantErrors: map[string]error{},
+		},
+		{
+			name: "failed scan",
+			opts: remote.ScannerOptions{"VERIPHONE_API_KEY": "secret"},
+			supplier: &veriphoneSupplierMock{
+				err: dummyError,
+			},
+			expected: map[string]interface{}{},
+			wantErrors: map[string]error{
+				"veriphone": dummyError,
+			},
+		},
+		{
+			name:       "should not run without an API key",
+			opts:       remote.ScannerOptions{},
+			supplier:   &veriphoneSupplierMock{},
+			expected:   map[string]interface{}{},
+			wantErrors: map[string]error{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := remote.NewVeriphoneScanner(tt.supplier)
+			lib := remote.NewLibrary(filter.NewEngine())
+			lib.AddScanner(scanner)
+
+			got, errs := lib.Scan(dummyNumber, tt.opts)
+			if len(tt.wantErrors) > 0 {
+				assert.Equal(t, tt.wantErrors, errs)
+			} else {
+				assert.Len(t, errs, 0)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/web/client/.gitignore
+++ b/web/client/.gitignore
@@ -1,6 +1,9 @@
 .DS_Store
 node_modules
-/dist
+/dist/*
+# dist/index.html is hand-written now (the Vue toolchain here doesn't build on
+# Windows - native module compile failure), not generated - keep it tracked.
+!/dist/index.html
 
 /tests/e2e/videos/
 /tests/e2e/screenshots/

--- a/web/client/dist/index.html
+++ b/web/client/dist/index.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PhoneInfoga</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #0f1115;
+    --panel: #171a21;
+    --panel-border: #262b36;
+    --text: #e8eaed;
+    --muted: #8b93a3;
+    --accent: #6cf;
+    --green: #4caf7d;
+    --yellow: #d9b44a;
+    --red: #e05a5a;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+  }
+  header {
+    padding: 2rem 1.5rem 1rem;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+  h1 { margin: 0 0 .25rem; font-size: 1.5rem; }
+  .subtitle { color: var(--muted); font-size: .9rem; margin: 0; }
+  form {
+    display: flex;
+    gap: .5rem;
+    max-width: 900px;
+    margin: 1.5rem auto 0;
+    padding: 0 1.5rem;
+  }
+  input[type=text] {
+    flex: 1;
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    color: var(--text);
+    padding: .7rem .9rem;
+    border-radius: 8px;
+    font-size: 1rem;
+  }
+  input[type=text]:focus { outline: 2px solid var(--accent); border-color: transparent; }
+  button {
+    background: var(--accent);
+    color: #06202e;
+    border: none;
+    font-weight: 600;
+    padding: .7rem 1.4rem;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  button:hover { opacity: .9; }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+  main {
+    max-width: 900px;
+    margin: 1.5rem auto 4rem;
+    padding: 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: .9rem;
+  }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--panel-border);
+    border-radius: 10px;
+    padding: 1rem 1.2rem;
+  }
+  .card-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .5rem;
+  }
+  .card-title h2 {
+    font-size: 1rem;
+    margin: 0;
+    text-transform: none;
+  }
+  .status {
+    font-size: .78rem;
+    padding: .15rem .5rem;
+    border-radius: 999px;
+    white-space: nowrap;
+  }
+  .status.pending { color: var(--muted); }
+  .status.skipped { background: #262b36; color: var(--muted); }
+  .status.error { background: rgba(224,90,90,.15); color: var(--red); }
+  .status.ok { background: rgba(76,175,125,.15); color: var(--green); }
+  .kv { font-size: .92rem; line-height: 1.7; }
+  .kv .row { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .kv .k { color: var(--muted); min-width: 11rem; }
+  .kv .v { word-break: break-word; }
+  .kv .v a { color: var(--accent); }
+  .kv ul { margin: .2rem 0 .6rem; padding-left: 1.1rem; }
+  .kv li { margin-bottom: .4rem; }
+  .badge {
+    display: inline-block;
+    padding: .1rem .5rem;
+    border-radius: 999px;
+    font-size: .8rem;
+    font-weight: 600;
+  }
+  .badge.risk-elevated { background: rgba(224,90,90,.18); color: var(--red); }
+  .badge.risk-uncertain { background: rgba(217,180,74,.18); color: var(--yellow); }
+  .badge.risk-low { background: rgba(76,175,125,.18); color: var(--green); }
+  .badge.risk-unknown { background: #262b36; color: var(--muted); }
+  .empty { color: var(--muted); font-style: italic; }
+  footer { text-align: center; color: var(--muted); font-size: .8rem; padding-bottom: 2rem; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>PhoneInfoga</h1>
+  <p class="subtitle">OSINT scan + scam-check for a phone number</p>
+</header>
+
+<form id="scan-form">
+  <input type="text" id="number-input" placeholder="+16502530000" autocomplete="off" autofocus>
+  <button type="submit" id="scan-btn">Scan</button>
+</form>
+
+<main id="results"></main>
+
+<footer>Runs entirely against this server's own scanners - no data leaves it except to each scanner's own API.</footer>
+
+<script>
+const resultsEl = document.getElementById('results');
+const form = document.getElementById('scan-form');
+const input = document.getElementById('number-input');
+const btn = document.getElementById('scan-btn');
+
+const humanize = (key) => key
+  .replace(/([a-z])([A-Z])/g, '$1 $2')
+  .replace(/_/g, ' ')
+  .replace(/^./, c => c.toUpperCase());
+
+const urlRe = /^https?:\/\/\S+$/;
+
+function renderValue(val) {
+  if (val === null || val === undefined || val === '') return null;
+
+  if (Array.isArray(val)) {
+    if (val.length === 0) return null;
+    const ul = document.createElement('ul');
+    val.forEach(item => {
+      const li = document.createElement('li');
+      if (typeof item === 'object') {
+        li.appendChild(renderObject(item));
+      } else {
+        li.appendChild(renderScalar(String(item)));
+      }
+      ul.appendChild(li);
+    });
+    return ul;
+  }
+
+  if (typeof val === 'object') {
+    return renderObject(val);
+  }
+
+  return renderScalar(val);
+}
+
+function renderScalar(val) {
+  const str = String(val);
+  if (urlRe.test(str)) {
+    const a = document.createElement('a');
+    a.href = str;
+    a.textContent = str;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    return a;
+  }
+  const span = document.createElement('span');
+  span.textContent = str;
+  return span;
+}
+
+function riskClass(risk) {
+  const r = String(risk).toLowerCase();
+  if (r.startsWith('elevated')) return 'risk-elevated';
+  if (r.startsWith('uncertain')) return 'risk-uncertain';
+  if (r.startsWith('low')) return 'risk-low';
+  return 'risk-unknown';
+}
+
+function renderObject(obj) {
+  const wrap = document.createElement('div');
+  wrap.className = 'kv';
+
+  Object.keys(obj).forEach(key => {
+    const val = obj[key];
+    const rendered = renderValue(val);
+    if (rendered === null) return;
+
+    const row = document.createElement('div');
+    row.className = 'row';
+
+    const k = document.createElement('div');
+    k.className = 'k';
+    k.textContent = humanize(key);
+    row.appendChild(k);
+
+    const v = document.createElement('div');
+    v.className = 'v';
+
+    if (key.toLowerCase().includes('risk') && typeof val === 'string') {
+      const badge = document.createElement('span');
+      badge.className = 'badge ' + riskClass(val);
+      badge.textContent = val;
+      v.appendChild(badge);
+    } else {
+      v.appendChild(rendered);
+    }
+
+    row.appendChild(v);
+    wrap.appendChild(row);
+  });
+
+  return wrap;
+}
+
+async function api(path, opts) {
+  const res = await fetch('/api' + path, {
+    method: opts && opts.body ? 'POST' : 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    body: opts && opts.body ? JSON.stringify(opts.body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  return { ok: res.ok, data };
+}
+
+// google* scanners just emit long lists of search-dork links - same rule as the
+// CLI console output: sort them after everything else.
+function sortScanners(scanners) {
+  return scanners.slice().sort((a, b) => {
+    const aGoogle = a.name.startsWith('google');
+    const bGoogle = b.name.startsWith('google');
+    if (aGoogle !== bGoogle) return aGoogle ? 1 : -1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function makeCard(scanner) {
+  const card = document.createElement('div');
+  card.className = 'card';
+
+  const title = document.createElement('div');
+  title.className = 'card-title';
+
+  const h2 = document.createElement('h2');
+  h2.textContent = scanner.name;
+  title.appendChild(h2);
+
+  const status = document.createElement('span');
+  status.className = 'status pending';
+  status.textContent = 'checking…';
+  title.appendChild(status);
+
+  card.appendChild(title);
+
+  const body = document.createElement('div');
+  card.appendChild(body);
+
+  resultsEl.appendChild(card);
+  return { card, status, body };
+}
+
+async function runScanner(number, scanner) {
+  const { status, body } = makeCard(scanner);
+
+  const dry = await api('/v2/scanners/' + scanner.name + '/dryrun', { body: { number } });
+  if (!dry.ok || !dry.data.success) {
+    status.className = 'status skipped';
+    status.textContent = 'skipped';
+    const p = document.createElement('p');
+    p.className = 'empty';
+    p.textContent = (dry.data && dry.data.error) || 'not applicable to this number';
+    body.appendChild(p);
+    return;
+  }
+
+  const run = await api('/v2/scanners/' + scanner.name + '/run', { body: { number } });
+  if (!run.ok) {
+    status.className = 'status error';
+    status.textContent = 'error';
+    const p = document.createElement('p');
+    p.className = 'empty';
+    p.textContent = (run.data && run.data.error) || 'request failed';
+    body.appendChild(p);
+    return;
+  }
+
+  status.className = 'status ok';
+  status.textContent = 'done';
+  const rendered = renderValue(run.data.result);
+  if (rendered) {
+    body.appendChild(rendered);
+  } else {
+    const p = document.createElement('p');
+    p.className = 'empty';
+    p.textContent = 'no data returned';
+    body.appendChild(p);
+  }
+}
+
+async function scan(number) {
+  resultsEl.innerHTML = '';
+  btn.disabled = true;
+
+  try {
+    const { ok, data } = await api('/v2/scanners');
+    if (!ok || !data.scanners) {
+      resultsEl.innerHTML = '<p class="empty">Could not load scanner list.</p>';
+      return;
+    }
+
+    const scanners = sortScanners(data.scanners);
+    await Promise.all(scanners.map(s => runScanner(number, s)));
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const number = input.value.trim();
+  if (!number) return;
+  scan(number);
+});
+</script>
+
+</body>
+</html>

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -155,7 +155,7 @@ func TestApi(t *testing.T) {
 
 				assert.Equal(t, nil, err)
 				assert.Equal(t, 200, res.Result().StatusCode)
-				assert.Equal(t, `{"success":true,"result":{"valid":true,"number":"79516566591","local_format":"9516566591","international_format":"+79516566591","country_prefix":"+7","country_code":"RU","country_name":"Russian Federation","location":"Saint Petersburg and Leningrad Oblast","carrier":"OJSC St. Petersburg Telecom (OJSC Tele2-Saint-Petersburg)","line_type":"mobile"}}`, string(body))
+				assert.Equal(t, `{"success":true,"result":{"valid":true,"number":"79516566591","local_format":"9516566591","international_format":"+79516566591","country_prefix":"+7","country_code":"RU","country_name":"Russian Federation","location":"Saint Petersburg and Leningrad Oblast","carrier":"OJSC St. Petersburg Telecom (OJSC Tele2-Saint-Petersburg)","line_type":"mobile","spoof_risk":"low - mobile line with a named carrier"}}`, string(body))
 
 				assert.Equal(t, gock.IsDone(), true, "there should have no pending mocks")
 			})


### PR DESCRIPTION
## Summary

- **Nomorobo & Should I Answer scanners** - free, no-API-key US/Canada lookups, each pulling the community verdict straight out of a stable HTML field (Nomorobo's meta description, shouldianswer.com's CSS score class).
- **Numverify legacy-endpoint fallback** - free keys signed up directly at numverify.com only work against the old `apilayer.net` endpoint (plain HTTP, `access_key` query param), not the current `apilayer.com` marketplace endpoint (HTTPS, header auth). Tries the marketplace endpoint first, falls back to the legacy one only on 401, so both key types work with zero config.
- **Spoof-risk signal on the Numverify scanner** - derives a rough "likely spoofable" signal from carrier + line-type: flags VOIP line types, known wholesale/VOIP carriers (Bandwidth, Level 3, Twilio, etc. - what Google Voice and similar app-based numbers actually resolve to), and the landline-with-no-carrier combination free-tier databases often produce for mislabeled ported/VOIP numbers. It's a proxy, not a verdict - documented as such in the code, since no phone-number lookup can determine whether a specific call was actually spoofed.
- **Veriphone scanner** - a second, independent carrier/line-type source to cross-check against Numverify (1000 free lookups/month, real HTTPS, no legacy-endpoint dance needed).
- **FTC Do Not Call complaint scanner** - the documented `api.ftc.gov` endpoint turned out to be dead: verified it returns identical static/sandbox data regardless of API key or query params (tested `DEMO_KEY` and a real key side by side - same record IDs, `limit` silently ignored). Found the real data source instead: FTC publishes genuine daily complaint CSVs at a predictable `ftc.gov` URL with no auth required. No server-side phone filter exists, so this checks the last published week and matches client-side.
- **Console output**: `google*` scanners (googlesearch, googlecse) now sort after everything else - they just emit long lists of search-dork links, which was pushing the more concise, higher-signal scanner results below the fold.
- **New web UI**: replaced the placeholder client with a hand-written HTML/CSS/vanilla-JS dashboard. The bundled Vue2 frontend doesn't build here (`deasync` needs node-gyp + Python + VS Build Tools) and its scanner list is hardcoded anyway, so it wouldn't pick up the new scanners. This one calls the existing v2 REST API (`GET /v2/scanners`, `POST /v2/scanners/:name/{dryrun,run}`) generically, so it stays in sync with whatever scanners are registered - no build step, no new dependency.

## Test plan

- [x] `go build .` succeeds
- [x] `go test ./...` passes (two pre-existing, unrelated Windows-only failures: `plugin` package isn't implemented on Windows at all, and a MIME-type lookup difference for static JS - both fail identically on unmodified `master`)
- [x] All new scanners manually verified against live APIs/sites with a real US number
- [x] New web UI verified via curl against the real API (all 9 scanners, a skip case, and a live Veriphone VOIP result) plus a Node DOM-stub smoke test of the render logic (no browser available in the dev environment to check visually)